### PR TITLE
Finance 2/11: access gate, TOTP, and security hardening

### DIFF
--- a/datamays/settings.py
+++ b/datamays/settings.py
@@ -11,8 +11,11 @@ https://docs.djangoproject.com/en/6.0/ref/settings/
 """
 
 import os
+from datetime import timedelta
+
 import dj_database_url
 import sentry_sdk
+from django.core.exceptions import ImproperlyConfigured
 from pathlib import Path
 from dotenv import load_dotenv
 
@@ -20,17 +23,49 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 
 load_dotenv(os.path.join(BASE_DIR, ".env"))
 
+DATABASE_URL = os.getenv('DATABASE_URL')
+SECRET_KEY = os.getenv('SECRET_KEY', 'fallback-secret-key')
+DEBUG = os.getenv("DEBUG_FLAG", "False") == "True"
+WORKING_ENV = os.getenv('WORKING_ENV').lower()
+
+# SECRET_KEY signs session cookies. Silently falling back to a public literal
+# would let anyone forge a session for the finance app, so outside local dev
+# a missing key is fatal rather than merely unfortunate.
+if WORKING_ENV != 'dev' and SECRET_KEY == 'fallback-secret-key':
+    raise ImproperlyConfigured(
+        "SECRET_KEY is not set. Refusing to start with the placeholder key "
+        "outside local development, because it signs session cookies."
+    )
+
+
+def _scrub_finance_data(event, hint):
+    """Strip request, user, and frame locals from finance errors.
+
+    send_default_pii is on for the public site, which would otherwise ship
+    balances, transaction descriptions, and account identifiers to Sentry via
+    request bodies and stack-frame locals. Errors from /finance are reported
+    with the traceback only.
+    """
+    url = (event.get("request") or {}).get("url") or ""
+
+    if "/finance" in url:
+        event.pop("request", None)
+        event.pop("user", None)
+
+        for value in (event.get("exception") or {}).get("values", []):
+            for frame in (value.get("stacktrace") or {}).get("frames", []):
+                frame.pop("vars", None)
+
+    return event
+
+
 sentry_sdk.init(
     dsn=os.getenv('SENTRY_DSN'),
     # Add data like request headers and IP for users,
     # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
     send_default_pii=True,
+    before_send=_scrub_finance_data,
 )
-
-DATABASE_URL = os.getenv('DATABASE_URL')
-SECRET_KEY = os.getenv('SECRET_KEY', 'fallback-secret-key')
-DEBUG = os.getenv("DEBUG_FLAG", "False") == "True"
-WORKING_ENV = os.getenv('WORKING_ENV').lower()
 
 if WORKING_ENV == 'dev':
     ALLOWED_HOSTS = [
@@ -60,6 +95,9 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django_otp',
+    'django_otp.plugins.otp_totp',
+    'axes',
 ]
 
 MIDDLEWARE = [
@@ -69,9 +107,34 @@ MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+    # Must follow AuthenticationMiddleware: it decorates request.user with
+    # is_verified() so views can tell a password-only session from one that
+    # has also cleared the second factor.
+    'django_otp.middleware.OTPMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    # Axes must come last so it observes the final authentication outcome.
+    'axes.middleware.AxesMiddleware',
 ]
+
+# AxesStandaloneBackend must be first — it short-circuits authentication for
+# locked-out credentials before the real backend ever checks a password.
+AUTHENTICATION_BACKENDS = [
+    'axes.backends.AxesStandaloneBackend',
+    'django.contrib.auth.backends.ModelBackend',
+]
+
+# /finance is internet-facing on a public repo, so the login form is a known
+# target. Five misses locks the (IP, username) pair for fifteen minutes.
+AXES_FAILURE_LIMIT = 5
+AXES_COOLOFF_TIME = timedelta(minutes=15)
+AXES_LOCKOUT_PARAMETERS = [["ip_address", "username"]]
+AXES_RESET_ON_SUCCESS = True
+AXES_LOCKOUT_TEMPLATE = "finance/lockout.html"
+
+LOGIN_URL = "finance:login"
+LOGIN_REDIRECT_URL = "finance:home"
+LOGOUT_REDIRECT_URL = "core:home"
 
 ROOT_URLCONF = 'datamays.urls'
 
@@ -158,6 +221,25 @@ if WORKING_ENV == 'dev':
 else:
     SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
     SECURE_SSL_REDIRECT = True
+
+    # Session and CSRF cookies now carry access to financial data, so they must
+    # never travel over plaintext HTTP.
+    SESSION_COOKIE_SECURE = True
+    CSRF_COOKIE_SECURE = True
+
+    # One year. Deliberately without preload: preloading is effectively
+    # irreversible, and includeSubDomains already commits every current and
+    # future datamays.com subdomain to HTTPS.
+    SECURE_HSTS_SECONDS = 31536000
+    SECURE_HSTS_INCLUDE_SUBDOMAINS = True
+
+SESSION_COOKIE_HTTPONLY = True
+SESSION_COOKIE_SAMESITE = 'Lax'
+
+# Two weeks. Long enough that a phone isn't re-authenticating constantly,
+# short enough that a stolen session eventually dies on its own. Second-factor
+# verification is what makes the long window acceptable.
+SESSION_COOKIE_AGE = 60 * 60 * 24 * 14
 
 if WORKING_ENV == 'dev':
     REDIRECT_DOMAIN = 'http://localhost:8000/'

--- a/datamays/urls.py
+++ b/datamays/urls.py
@@ -17,6 +17,8 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path, include
 
+handler403 = "datamays.views.permission_denied"
+
 urlpatterns = [
     path('admin/', admin.site.urls),
     path("", include("core.urls")),

--- a/datamays/views.py
+++ b/datamays/views.py
@@ -1,0 +1,16 @@
+from django.shortcuts import render
+
+
+def permission_denied(request, exception=None):
+    """Project-wide 403 handler.
+
+    The finance app gets its own page. Anything else keeps the site's
+    standard one.
+    """
+    template = (
+        "finance/403.html"
+        if request.path.startswith("/finance")
+        else "403.html"
+    )
+
+    return render(request, template, status=403)

--- a/finance/access.py
+++ b/finance/access.py
@@ -1,20 +1,59 @@
 """Access control for the finance app.
 
-Every finance view must inherit from FinanceAccessMixin. The gate is
-deliberately a hard PermissionDenied rather than a redirect to a login page:
-an unauthenticated visitor should not learn that a login form exists here, let
-alone what it protects.
+Three gates, in order, and the order matters:
 
-The finance/auth branch replaces the stock 403 with the household's own page
-and adds group membership plus TOTP checks.
+1. Authenticated at all?
+2. A member of the household (the `finance` group)?
+3. Cleared the second factor in this session?
+
+The first two failures render the same 403 for anyone who has no business
+here. It is deliberately not a redirect to a login page: a stranger poking at
+/finance should not learn that a login form exists, nor what it protects. The
+third failure *is* a redirect — by then the visitor has proven they hold a
+household account, so guiding them through TOTP leaks nothing.
 """
 
 from django.core.exceptions import PermissionDenied
+from django.shortcuts import redirect
+from django.urls import reverse
+
+FINANCE_GROUP = "finance"
+
+
+def is_household_member(user) -> bool:
+    return user.is_authenticated and user.groups.filter(name=FINANCE_GROUP).exists()
+
+
+class HouseholdMemberMixin:
+    """Gates 1 and 2 only.
+
+    For the auth screens themselves, which an authenticated member must reach
+    precisely because they have not cleared the second factor yet.
+    """
+
+    def dispatch(self, request, *args, **kwargs):
+        if not is_household_member(request.user):
+            raise PermissionDenied
+
+        return super().dispatch(request, *args, **kwargs)
 
 
 class FinanceAccessMixin:
     def dispatch(self, request, *args, **kwargs):
-        if not request.user.is_authenticated:
+        if not is_household_member(request.user):
             raise PermissionDenied
 
+        if not request.user.is_verified():
+            return redirect(self._second_factor_url(request))
+
         return super().dispatch(request, *args, **kwargs)
+
+    @staticmethod
+    def _second_factor_url(request):
+        from django_otp.plugins.otp_totp.models import TOTPDevice
+
+        has_device = TOTPDevice.objects.filter(
+            user=request.user, confirmed=True
+        ).exists()
+
+        return reverse("finance:otp_verify" if has_device else "finance:otp_setup")

--- a/finance/forms.py
+++ b/finance/forms.py
@@ -1,0 +1,70 @@
+from django import forms
+from django.contrib.auth.forms import AuthenticationForm
+
+FIELD_CLASSES = (
+    "w-full rounded-button border border-border bg-background px-4 py-3 "
+    "text-text-primary placeholder:text-text-muted focus:outline-none "
+    "focus:ring-2 focus:ring-primary"
+)
+
+OTP_FIELD_CLASSES = (
+    "w-full rounded-button border border-border bg-background px-4 py-3 "
+    "text-center font-mono text-2xl tracking-[0.4em] text-text-primary "
+    "focus:outline-none focus:ring-2 focus:ring-primary"
+)
+
+
+class FinanceLoginForm(AuthenticationForm):
+    """Styled login form. Authentication behaviour is Django's."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.fields["username"].widget.attrs.update(
+            {
+                "class": FIELD_CLASSES,
+                "placeholder": "Username",
+                "autocomplete": "username",
+                "autofocus": True,
+            }
+        )
+        self.fields["password"].widget.attrs.update(
+            {
+                "class": FIELD_CLASSES,
+                "placeholder": "Password",
+                "autocomplete": "current-password",
+            }
+        )
+
+
+class OTPTokenForm(forms.Form):
+    """A six-digit TOTP code.
+
+    inputmode="numeric" and autocomplete="one-time-code" are what make this
+    bearable on a phone: iOS offers the code from the authenticator app
+    directly above the keyboard.
+    """
+
+    token = forms.CharField(
+        label="Authentication code",
+        max_length=6,
+        min_length=6,
+        widget=forms.TextInput(
+            attrs={
+                "class": OTP_FIELD_CLASSES,
+                "placeholder": "000000",
+                "inputmode": "numeric",
+                "pattern": "[0-9]*",
+                "autocomplete": "one-time-code",
+                "autofocus": True,
+            }
+        ),
+    )
+
+    def clean_token(self):
+        token = self.cleaned_data["token"].strip().replace(" ", "")
+
+        if not token.isdigit():
+            raise forms.ValidationError("Codes are six digits.")
+
+        return token

--- a/finance/management/commands/create_finance_user.py
+++ b/finance/management/commands/create_finance_user.py
@@ -1,0 +1,75 @@
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+
+from finance.access import FINANCE_GROUP
+
+
+class Command(BaseCommand):
+    help = (
+        "Create (or promote) a user and add them to the finance group. "
+        "Membership of that group is what grants access to /finance."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument("username")
+        parser.add_argument("--email", default="")
+        parser.add_argument("--first-name", default="", dest="first_name")
+
+    @transaction.atomic
+    def handle(self, *args, **options):
+        User = get_user_model()
+        username = options["username"]
+
+        group, created_group = Group.objects.get_or_create(name=FINANCE_GROUP)
+        if created_group:
+            self.stdout.write(f"Created the '{FINANCE_GROUP}' group.")
+
+        user, created = User.objects.get_or_create(
+            username=username,
+            defaults={
+                "email": options["email"],
+                "first_name": options["first_name"],
+            },
+        )
+
+        if created:
+            # No password is set here, so the account cannot be logged into
+            # until one is chosen interactively below.
+            password = self._prompt_for_password(username)
+            user.set_password(password)
+            user.save()
+            self.stdout.write(self.style.SUCCESS(f"Created user '{username}'."))
+        else:
+            self.stdout.write(f"User '{username}' already exists; adding to group.")
+
+        user.groups.add(group)
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"'{username}' can now reach /finance. They will be prompted to "
+                "enrol an authenticator app on first sign-in."
+            )
+        )
+
+    def _prompt_for_password(self, username):
+        from getpass import getpass
+
+        for _ in range(3):
+            password = getpass(f"Password for {username}: ")
+            confirmation = getpass("Confirm: ")
+
+            if password != confirmation:
+                self.stderr.write("Passwords did not match.")
+                continue
+
+            if len(password) < 12:
+                self.stderr.write(
+                    "Use at least 12 characters — this guards real account data."
+                )
+                continue
+
+            return password
+
+        raise CommandError("Could not set a password.")

--- a/finance/redirects.py
+++ b/finance/redirects.py
@@ -1,0 +1,36 @@
+"""Redirect-target validation.
+
+`?next=` and hidden `next` fields are attacker-controllable, so a bare
+`redirect(request.POST["next"])` will happily send a signed-in person to
+another host. Everything that honours a caller-supplied destination goes
+through here.
+"""
+
+
+def is_safe_path(value) -> bool:
+    """True only for same-site absolute paths.
+
+    Rejects scheme-relative (`//evil.example`), absolute URLs, and anything
+    carrying a scheme such as `javascript:`. Backslashes and newlines are
+    rejected too — some browsers normalise the former to forward slashes, and
+    the latter would allow header injection.
+    """
+    if not value or not isinstance(value, str):
+        return False
+
+    if not value.startswith("/") or value.startswith("//"):
+        return False
+
+    return "\\" not in value and "\r" not in value and "\n" not in value
+
+
+def safe_next(request, default):
+    """The caller's requested destination, or `default` if it is not safe.
+
+    `default` is required rather than inferred. Falling back to the current
+    path suits a list page that should stay put, but on an auth screen it
+    would bounce the visitor straight back to the page they just cleared.
+    """
+    candidate = request.POST.get("next") or request.GET.get("next")
+
+    return candidate if is_safe_path(candidate) else default

--- a/finance/templates/finance/403.html
+++ b/finance/templates/finance/403.html
@@ -1,0 +1,26 @@
+{% extends "finance/base_auth.html" %}
+{% block title %}Nothing to see here{% endblock %}
+
+{% block auth_content %}
+<div class="text-center">
+  <p class="text-6xl" aria-hidden="true">🕵️</p>
+
+  <h1 class="mt-6 text-3xl font-extrabold tracking-tight">Get out of here, nosey!</h1>
+
+  <p class="mt-3 text-text-secondary">
+    This corner of the site is strictly a two-person operation, and you are not
+    one of the two.
+  </p>
+
+  <a href="{% url 'core:home' %}"
+     class="mt-8 inline-block rounded-button bg-primary px-6 py-3 font-medium text-white transition hover:bg-primary-600">
+    Back to datamays.com
+  </a>
+
+  <p class="mt-10 text-xs text-text-muted">
+    <a href="{% url 'finance:login' %}" class="underline underline-offset-4 transition hover:text-text-secondary">
+      …unless you live here
+    </a>
+  </p>
+</div>
+{% endblock %}

--- a/finance/templates/finance/base_auth.html
+++ b/finance/templates/finance/base_auth.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>{% block title %}{{ page_title|default:"Household Finance" }}{% endblock %}</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <meta name="theme-color" content="#0B0F19" />
+  <meta name="robots" content="noindex, nofollow" />
+  {% load static %}
+  <link href="{% static 'css/tailwind.css' %}" rel="stylesheet" />
+  <link rel="icon" type="image/x-icon" href="{% static 'img/favicon.ico' %}">
+</head>
+
+<body class="flex min-h-screen flex-col bg-background font-sans text-text-primary antialiased">
+  <main class="flex flex-1 items-center justify-center px-4 py-12">
+    <div class="w-full max-w-sm">
+      {% block auth_content %}{% endblock %}
+    </div>
+  </main>
+</body>
+</html>

--- a/finance/templates/finance/lockout.html
+++ b/finance/templates/finance/lockout.html
@@ -1,0 +1,20 @@
+{% extends "finance/base_auth.html" %}
+{% block title %}Locked out{% endblock %}
+
+{% block auth_content %}
+<div class="text-center">
+  <p class="text-6xl" aria-hidden="true">🔒</p>
+
+  <h1 class="mt-6 text-2xl font-extrabold tracking-tight">Too many attempts</h1>
+
+  <p class="mt-3 text-text-secondary">
+    This username and address are locked for 15 minutes. If that was you, go
+    make a coffee. If it wasn't, your password is being guessed at — change it.
+  </p>
+
+  <a href="{% url 'core:home' %}"
+     class="mt-8 inline-block rounded-button border border-border bg-surface px-6 py-3 font-medium transition hover:bg-muted">
+    Back to datamays.com
+  </a>
+</div>
+{% endblock %}

--- a/finance/templates/finance/login.html
+++ b/finance/templates/finance/login.html
@@ -1,0 +1,41 @@
+{% extends "finance/base_auth.html" %}
+{% load static %}
+{% block title %}Sign in — Household Finance{% endblock %}
+
+{% block auth_content %}
+<div class="mb-8 flex items-center justify-center gap-2">
+  <img src="{% static 'img/datamays-logo-transparent.png' %}" alt="" class="h-8 w-8" />
+  <span class="text-lg font-bold tracking-tight">Household Finance</span>
+</div>
+
+<form method="post" class="space-y-4">
+  {% csrf_token %}
+
+  {% if form.non_field_errors %}
+    <div class="rounded-button border border-error/40 bg-error/10 px-4 py-3 text-sm text-error" role="alert">
+      {% for error in form.non_field_errors %}<p>{{ error }}</p>{% endfor %}
+    </div>
+  {% endif %}
+
+  <div>
+    <label for="{{ form.username.id_for_label }}" class="sr-only">Username</label>
+    {{ form.username }}
+  </div>
+
+  <div>
+    <label for="{{ form.password.id_for_label }}" class="sr-only">Password</label>
+    {{ form.password }}
+  </div>
+
+  <button type="submit"
+          class="w-full rounded-button bg-primary px-6 py-3 font-medium text-white transition hover:bg-primary-600">
+    Sign in
+  </button>
+</form>
+
+<p class="mt-8 text-center text-xs text-text-muted">
+  <a href="{% url 'core:home' %}" class="underline underline-offset-4 transition hover:text-text-secondary">
+    Back to datamays.com
+  </a>
+</p>
+{% endblock %}

--- a/finance/templates/finance/otp_setup.html
+++ b/finance/templates/finance/otp_setup.html
@@ -1,0 +1,46 @@
+{% extends "finance/base_auth.html" %}
+{% block title %}Set up two-factor — Household Finance{% endblock %}
+
+{% block auth_content %}
+<div class="text-center">
+  <h1 class="text-2xl font-extrabold tracking-tight">Set up two-factor</h1>
+  <p class="mt-2 text-sm text-text-secondary">
+    Scan this with an authenticator app — 1Password, Authy, Google
+    Authenticator — then enter the code it shows.
+  </p>
+</div>
+
+{# White plate: QR codes need light quiet-zones to scan reliably. #}
+<div class="mx-auto mt-6 w-48 rounded-card bg-white p-3 [&_svg]:h-full [&_svg]:w-full">
+  {{ qr_svg }}
+</div>
+
+<details class="mt-4 text-center text-xs text-text-muted">
+  <summary class="cursor-pointer underline underline-offset-4">Can't scan it?</summary>
+  <p class="mt-3">Enter this key manually:</p>
+  <code class="mt-2 block break-all rounded bg-muted px-3 py-2 font-mono text-[11px] text-text-secondary">{{ secret }}</code>
+</details>
+
+<form method="post" class="mt-8 space-y-4">
+  {% csrf_token %}
+
+  {% if form.non_field_errors %}
+    <div class="rounded-button border border-error/40 bg-error/10 px-4 py-3 text-sm text-error" role="alert">
+      {% for error in form.non_field_errors %}<p>{{ error }}</p>{% endfor %}
+    </div>
+  {% endif %}
+
+  <div>
+    <label for="{{ form.token.id_for_label }}" class="sr-only">Authentication code</label>
+    {{ form.token }}
+    {% if form.token.errors %}
+      <p class="mt-2 text-sm text-error" role="alert">{{ form.token.errors.0 }}</p>
+    {% endif %}
+  </div>
+
+  <button type="submit"
+          class="w-full rounded-button bg-primary px-6 py-3 font-medium text-white transition hover:bg-primary-600">
+    Confirm and finish
+  </button>
+</form>
+{% endblock %}

--- a/finance/templates/finance/otp_verify.html
+++ b/finance/templates/finance/otp_verify.html
@@ -1,0 +1,41 @@
+{% extends "finance/base_auth.html" %}
+{% block title %}Two-factor — Household Finance{% endblock %}
+
+{% block auth_content %}
+<div class="text-center">
+  <h1 class="text-2xl font-extrabold tracking-tight">Enter your code</h1>
+  <p class="mt-2 text-sm text-text-secondary">
+    Open your authenticator app and type the six digits for Household Finance.
+  </p>
+</div>
+
+<form method="post" class="mt-8 space-y-4">
+  {% csrf_token %}
+
+  {% if form.non_field_errors %}
+    <div class="rounded-button border border-error/40 bg-error/10 px-4 py-3 text-sm text-error" role="alert">
+      {% for error in form.non_field_errors %}<p>{{ error }}</p>{% endfor %}
+    </div>
+  {% endif %}
+
+  <div>
+    <label for="{{ form.token.id_for_label }}" class="sr-only">Authentication code</label>
+    {{ form.token }}
+    {% if form.token.errors %}
+      <p class="mt-2 text-sm text-error" role="alert">{{ form.token.errors.0 }}</p>
+    {% endif %}
+  </div>
+
+  <button type="submit"
+          class="w-full rounded-button bg-primary px-6 py-3 font-medium text-white transition hover:bg-primary-600">
+    Verify
+  </button>
+</form>
+
+<form method="post" action="{% url 'finance:logout' %}" class="mt-8 text-center">
+  {% csrf_token %}
+  <button type="submit" class="text-xs text-text-muted underline underline-offset-4 transition hover:text-text-secondary">
+    Sign out
+  </button>
+</form>
+{% endblock %}

--- a/finance/templates/finance/partials/header.html
+++ b/finance/templates/finance/partials/header.html
@@ -41,6 +41,14 @@
            class="block px-4 py-2.5 text-sm text-text-secondary transition hover:bg-muted hover:text-text-primary">Preferences</a>
         <a href="{% url 'core:home' %}" role="menuitem"
            class="block border-t border-border px-4 py-2.5 text-sm text-text-muted transition hover:bg-muted hover:text-text-primary">Back to datamays.com</a>
+
+        <form method="post" action="{% url 'finance:logout' %}" class="border-t border-border">
+          {% csrf_token %}
+          <button type="submit" role="menuitem"
+                  class="block w-full px-4 py-2.5 text-left text-sm text-text-secondary transition hover:bg-muted hover:text-text-primary">
+            Sign out
+          </button>
+        </form>
       </div>
     </div>
 

--- a/finance/tests/test_access.py
+++ b/finance/tests/test_access.py
@@ -1,10 +1,11 @@
 from django.conf import settings
 from django.contrib.auth.models import Group, User
-from django.test import RequestFactory, TestCase
+from django.test import RequestFactory, SimpleTestCase, TestCase
 from django.urls import reverse
 from django_otp.plugins.otp_totp.models import TOTPDevice
 
 from finance.access import FINANCE_GROUP
+from finance.redirects import is_safe_path, safe_next
 from finance.views_auth import OTPVerifyView
 
 PROTECTED_URL_NAMES = [
@@ -180,3 +181,38 @@ class OTPRedirectSafetyTests(TestCase):
 
     def test_relative_next_is_honoured(self):
         self.assertEqual(self._success_url_for("/finance/spend/"), "/finance/spend/")
+
+
+class RedirectSafetyTests(SimpleTestCase):
+    """`next` is attacker-controllable wherever it is honoured."""
+
+    def test_hostile_targets_are_rejected(self):
+        hostile = [
+            "//evil.example.com",
+            "https://evil.example.com",
+            "http://evil.example.com",
+            "javascript:alert(1)",
+            "\\\\evil.example.com",
+            "/finance/\r\nSet-Cookie: x=1",
+            "",
+            None,
+        ]
+
+        for value in hostile:
+            with self.subTest(next=value):
+                self.assertFalse(is_safe_path(value))
+
+    def test_same_site_paths_are_allowed(self):
+        for value in ["/finance/", "/finance/transactions/?review=1"]:
+            with self.subTest(next=value):
+                self.assertTrue(is_safe_path(value))
+
+    def test_safe_next_uses_the_caller_supplied_default_when_unsafe(self):
+        request = RequestFactory().post("/finance/x/", {"next": "//evil.example.com"})
+
+        self.assertEqual(safe_next(request, default="/finance/"), "/finance/")
+
+    def test_safe_next_honours_a_relative_target(self):
+        request = RequestFactory().post("/finance/x/", {"next": "/finance/spend/"})
+
+        self.assertEqual(safe_next(request, default="/finance/"), "/finance/spend/")

--- a/finance/tests/test_access.py
+++ b/finance/tests/test_access.py
@@ -1,8 +1,13 @@
-from django.contrib.auth.models import User
-from django.test import TestCase
+from django.conf import settings
+from django.contrib.auth.models import Group, User
+from django.test import RequestFactory, TestCase
 from django.urls import reverse
+from django_otp.plugins.otp_totp.models import TOTPDevice
 
-FINANCE_URL_NAMES = [
+from finance.access import FINANCE_GROUP
+from finance.views_auth import OTPVerifyView
+
+PROTECTED_URL_NAMES = [
     "home",
     "transactions",
     "spend",
@@ -12,25 +17,166 @@ FINANCE_URL_NAMES = [
     "preferences",
 ]
 
+PASSWORD = "a-long-enough-test-password"
 
-class FinanceAccessTests(TestCase):
-    def test_every_finance_route_is_closed_to_anonymous_visitors(self):
-        for name in FINANCE_URL_NAMES:
+
+def make_user(username, *, in_group=True, with_device=False):
+    user = User.objects.create_user(username=username, password=PASSWORD)
+
+    if in_group:
+        group, _ = Group.objects.get_or_create(name=FINANCE_GROUP)
+        user.groups.add(group)
+
+    if with_device:
+        TOTPDevice.objects.create(user=user, name="test", confirmed=True)
+
+    return user
+
+
+class AnonymousAccessTests(TestCase):
+    def test_every_protected_route_returns_403(self):
+        for name in PROTECTED_URL_NAMES:
             with self.subTest(route=name):
                 response = self.client.get(reverse(f"finance:{name}"))
                 self.assertEqual(response.status_code, 403)
 
-    def test_anonymous_response_leaks_nothing_about_the_app(self):
+    def test_403_does_not_redirect_to_login(self):
+        # A redirect would confirm to a stranger that credentials exist here.
         response = self.client.get(reverse("finance:home"))
-        body = response.content.decode().lower()
-        for term in ["balance", "budget", "transaction", "account"]:
-            self.assertNotIn(term, body)
+        self.assertEqual(response.status_code, 403)
+        self.assertTemplateUsed(response, "finance/403.html")
 
-    def test_authenticated_user_reaches_the_app(self):
-        User.objects.create_user(username="maddie", password="correct-horse-battery")
-        self.client.login(username="maddie", password="correct-horse-battery")
+    def test_403_page_is_cheeky_and_leaks_no_financial_terms(self):
+        response = self.client.get(reverse("finance:home"))
+        body = response.content.decode()
+
+        self.assertIn("Get out of here, nosey!", body)
+        for term in ["balance", "budget", "transaction", "account"]:
+            self.assertNotIn(term, body.lower())
+
+    def test_login_page_is_reachable(self):
+        response = self.client.get(reverse("finance:login"))
+        self.assertEqual(response.status_code, 200)
+
+
+class NonMemberAccessTests(TestCase):
+    def test_authenticated_outsider_is_indistinguishable_from_a_stranger(self):
+        self.client.force_login(make_user("outsider", in_group=False))
+
+        response = self.client.get(reverse("finance:home"))
+
+        # Same 403, same page: a valid site login must not reveal that the
+        # finance app exists behind a group check.
+        self.assertEqual(response.status_code, 403)
+        self.assertTemplateUsed(response, "finance/403.html")
+
+
+class SecondFactorTests(TestCase):
+    def test_member_without_a_device_is_sent_to_enrolment(self):
+        self.client.force_login(make_user("david"))
+
+        response = self.client.get(reverse("finance:home"))
+
+        self.assertRedirects(response, reverse("finance:otp_setup"))
+
+    def test_member_with_a_device_is_challenged_before_seeing_data(self):
+        self.client.force_login(make_user("maddie", with_device=True))
+
+        response = self.client.get(reverse("finance:home"))
+
+        self.assertRedirects(response, reverse("finance:otp_verify"))
+
+    def test_password_alone_never_reaches_a_finance_page(self):
+        self.client.force_login(make_user("maddie", with_device=True))
+
+        for name in PROTECTED_URL_NAMES:
+            with self.subTest(route=name):
+                response = self.client.get(reverse(f"finance:{name}"))
+                self.assertEqual(response.status_code, 302)
+
+    def test_verified_session_reaches_the_app(self):
+        user = make_user("david", with_device=True)
+        self.client.force_login(user)
+
+        # Mirror what OTPSetupView/OTPVerifyView do on a correct code.
+        device = TOTPDevice.objects.get(user=user)
+        session = self.client.session
+        session["otp_device_id"] = device.persistent_id
+        session.save()
 
         response = self.client.get(reverse("finance:home"))
 
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "finance/home.html")
+
+
+class LoginFlowTests(TestCase):
+    """Exercises the real form POST, which is what Axes instruments."""
+
+    def test_correct_credentials_land_on_the_second_factor(self):
+        make_user("david")
+
+        response = self.client.post(
+            reverse("finance:login"),
+            {"username": "david", "password": PASSWORD},
+        )
+
+        # Signed in, but the session is not verified until TOTP is cleared.
+        self.assertRedirects(
+            response, reverse("finance:home"), target_status_code=302
+        )
+
+    def test_wrong_password_does_not_authenticate(self):
+        make_user("david")
+
+        response = self.client.post(
+            reverse("finance:login"),
+            {"username": "david", "password": "not-the-password"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.wsgi_request.user.is_authenticated)
+
+    def test_repeated_failures_lock_the_account_out(self):
+        make_user("david")
+
+        for _ in range(settings.AXES_FAILURE_LIMIT):
+            self.client.post(
+                reverse("finance:login"),
+                {"username": "david", "password": "wrong"},
+            )
+
+        # Even the correct password is refused once the lockout engages.
+        response = self.client.post(
+            reverse("finance:login"),
+            {"username": "david", "password": PASSWORD},
+        )
+
+        self.assertEqual(response.status_code, 429)
+        self.assertIn("Too many attempts", response.content.decode())
+        self.assertFalse(response.wsgi_request.user.is_authenticated)
+
+
+class OTPRedirectSafetyTests(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def _success_url_for(self, next_value):
+        view = OTPVerifyView()
+        view.request = self.factory.get(reverse("finance:otp_verify"), {"next": next_value})
+        return view.get_success_url()
+
+    def test_next_parameter_cannot_bounce_to_another_host(self):
+        hostile = [
+            "//evil.example.com",
+            "https://evil.example.com",
+            "javascript:alert(1)",
+            "\\\\evil.example.com",
+        ]
+
+        for value in hostile:
+            with self.subTest(next=value):
+                self.assertEqual(self._success_url_for(value), reverse("finance:home"))
+
+    def test_relative_next_is_honoured(self):
+        self.assertEqual(self._success_url_for("/finance/spend/"), "/finance/spend/")

--- a/finance/tests/test_otp_enrolment.py
+++ b/finance/tests/test_otp_enrolment.py
@@ -1,0 +1,115 @@
+"""Full second-factor enrolment and challenge, using real TOTP codes."""
+
+import time
+
+from django.test import TestCase
+from django.urls import reverse
+from django_otp.oath import TOTP
+from django_otp.plugins.otp_totp.models import TOTPDevice
+
+from .test_access import make_user
+
+
+def current_token(device: TOTPDevice) -> str:
+    """The code an authenticator app would be showing right now."""
+    totp = TOTP(device.bin_key, device.step, device.t0, device.digits)
+    totp.time = time.time()
+
+    return f"{totp.token():0{device.digits}d}"
+
+
+class EnrolmentTests(TestCase):
+    def setUp(self):
+        self.user = make_user("david")
+        self.client.force_login(self.user)
+
+    def test_setup_page_offers_a_scannable_secret(self):
+        response = self.client.get(reverse("finance:otp_setup"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "<svg")
+
+        device = TOTPDevice.objects.get(user=self.user, confirmed=False)
+        self.assertContains(response, device.key)
+
+    def test_reloading_setup_keeps_the_same_secret(self):
+        # Otherwise a user who scans, then refreshes, holds a dead secret.
+        self.client.get(reverse("finance:otp_setup"))
+        first = TOTPDevice.objects.get(user=self.user, confirmed=False).key
+
+        self.client.get(reverse("finance:otp_setup"))
+        second = TOTPDevice.objects.get(user=self.user, confirmed=False).key
+
+        self.assertEqual(first, second)
+
+    def test_a_correct_code_confirms_the_device_and_opens_the_app(self):
+        self.client.get(reverse("finance:otp_setup"))
+        device = TOTPDevice.objects.get(user=self.user, confirmed=False)
+
+        response = self.client.post(
+            reverse("finance:otp_setup"), {"token": current_token(device)}
+        )
+
+        self.assertRedirects(response, reverse("finance:home"))
+
+        device.refresh_from_db()
+        self.assertTrue(device.confirmed)
+
+        # And the session is now verified, so the app is actually reachable.
+        self.assertEqual(self.client.get(reverse("finance:home")).status_code, 200)
+
+    def test_a_wrong_code_leaves_the_device_unconfirmed(self):
+        self.client.get(reverse("finance:otp_setup"))
+
+        response = self.client.post(reverse("finance:otp_setup"), {"token": "000000"})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(
+            TOTPDevice.objects.filter(user=self.user, confirmed=True).exists()
+        )
+        self.assertEqual(self.client.get(reverse("finance:home")).status_code, 302)
+
+
+class ChallengeTests(TestCase):
+    def setUp(self):
+        self.user = make_user("maddie")
+        self.device = TOTPDevice.objects.create(
+            user=self.user, name="test", confirmed=True
+        )
+        self.client.force_login(self.user)
+
+    def test_correct_code_verifies_the_session(self):
+        response = self.client.post(
+            reverse("finance:otp_verify"), {"token": current_token(self.device)}
+        )
+
+        self.assertRedirects(response, reverse("finance:home"))
+        self.assertEqual(self.client.get(reverse("finance:home")).status_code, 200)
+
+    def test_wrong_code_leaves_the_session_unverified(self):
+        response = self.client.post(reverse("finance:otp_verify"), {"token": "000000"})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self.client.get(reverse("finance:home")).status_code, 302)
+
+    def test_a_code_cannot_be_replayed(self):
+        token = current_token(self.device)
+
+        self.client.post(reverse("finance:otp_verify"), {"token": token})
+        self.client.post(reverse("finance:logout"))
+        self.client.force_login(self.user)
+
+        response = self.client.post(reverse("finance:otp_verify"), {"token": token})
+
+        # django-otp records the last used counter, so a captured code is dead.
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self.client.get(reverse("finance:home")).status_code, 302)
+
+    def test_already_verified_users_skip_the_challenge(self):
+        self.client.post(
+            reverse("finance:otp_verify"), {"token": current_token(self.device)}
+        )
+
+        response = self.client.get(reverse("finance:otp_verify"))
+
+        self.assertRedirects(response, reverse("finance:home"))

--- a/finance/tests/test_settings_hardening.py
+++ b/finance/tests/test_settings_hardening.py
@@ -1,0 +1,54 @@
+"""Tests for the project-level security fixes that shipped with the auth gate."""
+
+from django.test import SimpleTestCase
+
+from datamays.settings import _scrub_finance_data
+
+
+def event_with(url, *, frame_vars=None):
+    return {
+        "request": {"url": url, "data": {"password": "hunter2"}},
+        "user": {"id": 1, "username": "david"},
+        "exception": {
+            "values": [
+                {"stacktrace": {"frames": [{"vars": frame_vars or {"balance": "8412.19"}}]}}
+            ]
+        },
+    }
+
+
+class SentryScrubbingTests(SimpleTestCase):
+    def test_finance_events_lose_request_user_and_frame_locals(self):
+        event = _scrub_finance_data(event_with("https://datamays.com/finance/spend/"), {})
+
+        self.assertNotIn("request", event)
+        self.assertNotIn("user", event)
+
+        frame = event["exception"]["values"][0]["stacktrace"]["frames"][0]
+        self.assertNotIn("vars", frame)
+
+    def test_no_balance_survives_anywhere_in_a_finance_event(self):
+        event = _scrub_finance_data(
+            event_with(
+                "https://datamays.com/finance/",
+                frame_vars={"current_balance": "8412.19", "account": "…4471"},
+            ),
+            {},
+        )
+
+        self.assertNotIn("8412.19", str(event))
+        self.assertNotIn("4471", str(event))
+
+    def test_public_site_events_are_left_intact(self):
+        # send_default_pii is deliberately on for the portfolio site; the
+        # scrubber must not quietly degrade that reporting.
+        event = _scrub_finance_data(event_with("https://datamays.com/contact/"), {})
+
+        self.assertIn("request", event)
+        self.assertIn("user", event)
+        self.assertIn(
+            "vars", event["exception"]["values"][0]["stacktrace"]["frames"][0]
+        )
+
+    def test_events_without_request_data_do_not_crash_the_scrubber(self):
+        self.assertEqual(_scrub_finance_data({}, {}), {})

--- a/finance/urls.py
+++ b/finance/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from . import views
+from . import views, views_auth
 
 app_name = "finance"
 
@@ -12,4 +12,9 @@ urlpatterns = [
     path("savings/", views.SavingsView.as_view(), name="savings"),
     path("settings/", views.SettingsView.as_view(), name="settings"),
     path("preferences/", views.PreferencesView.as_view(), name="preferences"),
+    # Auth
+    path("login/", views_auth.FinanceLoginView.as_view(), name="login"),
+    path("logout/", views_auth.FinanceLogoutView.as_view(), name="logout"),
+    path("two-factor/setup/", views_auth.OTPSetupView.as_view(), name="otp_setup"),
+    path("two-factor/", views_auth.OTPVerifyView.as_view(), name="otp_verify"),
 ]

--- a/finance/views_auth.py
+++ b/finance/views_auth.py
@@ -13,6 +13,7 @@ from django_otp import login as otp_login
 from django_otp.plugins.otp_totp.models import TOTPDevice
 
 from .access import HouseholdMemberMixin
+from .redirects import safe_next
 from .forms import FinanceLoginForm, OTPTokenForm
 
 
@@ -143,11 +144,6 @@ class OTPVerifyView(HouseholdMemberMixin, FormView):
         return redirect(self.get_success_url())
 
     def get_success_url(self):
-        next_url = self.request.GET.get("next")
-
-        # Only same-site relative paths, so ?next= cannot bounce a verified
-        # session off to another host.
-        if next_url and next_url.startswith("/") and not next_url.startswith("//"):
-            return next_url
-
-        return reverse("finance:home")
+        # Shared validator rather than an inline check, so every place that
+        # honours a caller-supplied destination rejects the same things.
+        return safe_next(self.request, default=reverse("finance:home"))

--- a/finance/views_auth.py
+++ b/finance/views_auth.py
@@ -1,0 +1,153 @@
+"""Login, TOTP enrolment, and TOTP verification for the finance app."""
+
+from io import BytesIO
+
+import qrcode
+import qrcode.image.svg
+from django.contrib.auth.views import LoginView, LogoutView
+from django.shortcuts import redirect
+from django.urls import reverse, reverse_lazy
+from django.utils.safestring import mark_safe
+from django.views.generic import FormView
+from django_otp import login as otp_login
+from django_otp.plugins.otp_totp.models import TOTPDevice
+
+from .access import HouseholdMemberMixin
+from .forms import FinanceLoginForm, OTPTokenForm
+
+
+def _qr_svg(uri: str) -> str:
+    """Render an otpauth:// URI as an inline SVG.
+
+    SVG rather than PNG so there is no Pillow dependency, and inline rather
+    than a served image so the shared secret never becomes a fetchable URL.
+    """
+    image = qrcode.make(uri, image_factory=qrcode.image.svg.SvgPathImage)
+    buffer = BytesIO()
+    image.save(buffer)
+
+    return mark_safe(buffer.getvalue().decode())
+
+
+class FinanceLoginView(LoginView):
+    template_name = "finance/login.html"
+    form_class = FinanceLoginForm
+    redirect_authenticated_user = True
+
+
+class FinanceLogoutView(LogoutView):
+    next_page = reverse_lazy("core:home")
+
+
+class OTPSetupView(HouseholdMemberMixin, FormView):
+    """One-time enrolment of an authenticator app."""
+
+    template_name = "finance/otp_setup.html"
+    form_class = OTPTokenForm
+
+    def dispatch(self, request, *args, **kwargs):
+        if TOTPDevice.objects.filter(user=request.user, confirmed=True).exists():
+            return redirect("finance:otp_verify")
+
+        return super().dispatch(request, *args, **kwargs)
+
+    def get_device(self):
+        # Unconfirmed devices are re-used so that reloading the page does not
+        # invalidate a secret the user has already scanned.
+        device, _ = TOTPDevice.objects.get_or_create(
+            user=self.request.user,
+            confirmed=False,
+            defaults={"name": "Authenticator app"},
+        )
+        return device
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        device = self.get_device()
+
+        context["qr_svg"] = _qr_svg(device.config_url)
+        # Shown so a device that cannot scan can still be enrolled by hand.
+        context["secret"] = device.key
+        context["page_title"] = "Set up two-factor"
+
+        return context
+
+    def form_valid(self, form):
+        device = self.get_device()
+
+        if not device.verify_token(form.cleaned_data["token"]):
+            form.add_error(
+                "token",
+                "That code didn't match. Check your authenticator app and try "
+                "again — codes expire every 30 seconds.",
+            )
+            return self.form_invalid(form)
+
+        device.confirmed = True
+        device.name = "Authenticator app"
+        device.save(update_fields=["confirmed", "name"])
+
+        otp_login(self.request, device)
+
+        return redirect("finance:home")
+
+
+class OTPVerifyView(HouseholdMemberMixin, FormView):
+    """Second-factor challenge for a session that has only a password."""
+
+    template_name = "finance/otp_verify.html"
+    form_class = OTPTokenForm
+
+    def dispatch(self, request, *args, **kwargs):
+        if request.user.is_authenticated and request.user.is_verified():
+            return redirect("finance:home")
+
+        return super().dispatch(request, *args, **kwargs)
+
+    def get_device(self):
+        return TOTPDevice.objects.filter(
+            user=self.request.user, confirmed=True
+        ).first()
+
+    def dispatch_no_device(self):
+        return redirect("finance:otp_setup")
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["page_title"] = "Two-factor"
+        return context
+
+    def form_valid(self, form):
+        device = self.get_device()
+
+        if device is None:
+            return self.dispatch_no_device()
+
+        # django-otp throttles repeated failures with an increasing delay,
+        # which is what keeps a six-digit code from being brute-forceable.
+        allowed, _ = device.verify_is_allowed()
+
+        if not allowed:
+            form.add_error(
+                None,
+                "Too many incorrect codes. Wait a moment before trying again.",
+            )
+            return self.form_invalid(form)
+
+        if not device.verify_token(form.cleaned_data["token"]):
+            form.add_error("token", "That code didn't match. Try the current one.")
+            return self.form_invalid(form)
+
+        otp_login(self.request, device)
+
+        return redirect(self.get_success_url())
+
+    def get_success_url(self):
+        next_url = self.request.GET.get("next")
+
+        # Only same-site relative paths, so ?next= cannot bounce a verified
+        # session off to another host.
+        if next_url and next_url.startswith("/") and not next_url.startswith("//"):
+            return next_url
+
+        return reverse("finance:home")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,9 @@ dependencies = [
     "Markdown>=3.10,<4.0",
     "sentry-sdk[django]>=2.48.0",
     "cryptography>=50.0.0",
+    "django-otp>=1.7.0",
+    "qrcode>=8.2",
+    "django-axes>=8.3.1",
 ]
 
 [tool.uv]

--- a/static/css/tailwind.css
+++ b/static/css/tailwind.css
@@ -1221,6 +1221,10 @@ video {
   margin-top: 0.25rem;
 }
 
+.mt-10 {
+  margin-top: 2.5rem;
+}
+
 .mt-12 {
   margin-top: 3rem;
 }
@@ -1259,6 +1263,10 @@ video {
 
 .inline-block {
   display: inline-block;
+}
+
+.inline {
+  display: inline;
 }
 
 .flex {
@@ -1321,6 +1329,10 @@ video {
   width: 8rem;
 }
 
+.w-48 {
+  width: 12rem;
+}
+
 .w-52 {
   width: 13rem;
 }
@@ -1369,6 +1381,10 @@ video {
   max-width: none;
 }
 
+.max-w-sm {
+  max-width: 24rem;
+}
+
 .flex-1 {
   flex: 1 1 0%;
 }
@@ -1379,6 +1395,10 @@ video {
 
 .grow {
   flex-grow: 1;
+}
+
+.cursor-pointer {
+  cursor: pointer;
 }
 
 .flex-col {
@@ -1437,6 +1457,12 @@ video {
   margin-bottom: calc(3rem * var(--tw-space-y-reverse));
 }
 
+.space-y-4 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(1rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(1rem * var(--tw-space-y-reverse));
+}
+
 .space-y-6 > :not([hidden]) ~ :not([hidden]) {
   --tw-space-y-reverse: 0;
   margin-top: calc(1.5rem * calc(1 - var(--tw-space-y-reverse)));
@@ -1455,6 +1481,10 @@ video {
 
 .whitespace-nowrap {
   white-space: nowrap;
+}
+
+.break-all {
+  word-break: break-all;
 }
 
 .rounded {
@@ -1494,6 +1524,10 @@ video {
   border-color: rgb(46 58 73 / var(--tw-border-opacity, 1));
 }
 
+.border-error\/40 {
+  border-color: rgb(239 68 68 / 0.4);
+}
+
 .bg-accent {
   --tw-bg-opacity: 1;
   background-color: rgb(20 184 166 / var(--tw-bg-opacity, 1));
@@ -1506,6 +1540,10 @@ video {
 
 .bg-background\/95 {
   background-color: rgb(11 15 25 / 0.95);
+}
+
+.bg-error\/10 {
+  background-color: rgb(239 68 68 / 0.1);
 }
 
 .bg-muted {
@@ -1531,12 +1569,21 @@ video {
   background-color: rgb(17 24 39 / 0.5);
 }
 
+.bg-white {
+  --tw-bg-opacity: 1;
+  background-color: rgb(255 255 255 / var(--tw-bg-opacity, 1));
+}
+
 .p-10 {
   padding: 2.5rem;
 }
 
 .p-2 {
   padding: 0.5rem;
+}
+
+.p-3 {
+  padding: 0.75rem;
 }
 
 .p-6 {
@@ -1651,8 +1698,16 @@ video {
   padding-top: 1rem;
 }
 
+.text-left {
+  text-align: left;
+}
+
 .text-center {
   text-align: center;
+}
+
+.font-mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 }
 
 .font-sans {
@@ -1737,6 +1792,10 @@ video {
   line-height: 1.625;
 }
 
+.tracking-\[0\.4em\] {
+  letter-spacing: 0.4em;
+}
+
 .tracking-tight {
   letter-spacing: -0.025em;
 }
@@ -1744,6 +1803,11 @@ video {
 .text-accent {
   --tw-text-opacity: 1;
   color: rgb(20 184 166 / var(--tw-text-opacity, 1));
+}
+
+.text-error {
+  --tw-text-opacity: 1;
+  color: rgb(239 68 68 / var(--tw-text-opacity, 1));
 }
 
 .text-primary {
@@ -1774,6 +1838,14 @@ video {
 .text-white {
   --tw-text-opacity: 1;
   color: rgb(255 255 255 / var(--tw-text-opacity, 1));
+}
+
+.underline {
+  text-decoration-line: underline;
+}
+
+.underline-offset-4 {
+  text-underline-offset: 4px;
 }
 
 .antialiased {
@@ -1824,6 +1896,16 @@ video {
 
 [x-cloak] {
   display: none !important;
+}
+
+.placeholder\:text-text-muted::-moz-placeholder {
+  --tw-text-opacity: 1;
+  color: rgb(156 163 175 / var(--tw-text-opacity, 1));
+}
+
+.placeholder\:text-text-muted::placeholder {
+  --tw-text-opacity: 1;
+  color: rgb(156 163 175 / var(--tw-text-opacity, 1));
 }
 
 .hover\:bg-muted:hover {
@@ -1958,4 +2040,12 @@ video {
   .lg\:grid-cols-3 {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
+}
+
+.\[\&_svg\]\:h-full svg {
+  height: 100%;
+}
+
+.\[\&_svg\]\:w-full svg {
+  width: 100%;
 }

--- a/uv.lock
+++ b/uv.lock
@@ -44,6 +44,15 @@ wheels = [
 ]
 
 [[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
 name = "cryptography"
 version = "50.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -88,10 +97,13 @@ dependencies = [
     { name = "cryptography" },
     { name = "dj-database-url" },
     { name = "django" },
+    { name = "django-axes" },
+    { name = "django-otp" },
     { name = "gunicorn" },
     { name = "markdown" },
     { name = "psycopg", extra = ["binary"] },
     { name = "python-dotenv" },
+    { name = "qrcode" },
     { name = "sentry-sdk", extra = ["django"] },
     { name = "sqlparse" },
     { name = "typing-extensions" },
@@ -103,10 +115,13 @@ requires-dist = [
     { name = "cryptography", specifier = ">=50.0.0" },
     { name = "dj-database-url", specifier = ">=2.2,<3.0" },
     { name = "django", specifier = ">=6.0,<7.0" },
+    { name = "django-axes", specifier = ">=8.3.1" },
+    { name = "django-otp", specifier = ">=1.7.0" },
     { name = "gunicorn", specifier = ">=23.0,<24.0" },
     { name = "markdown", specifier = ">=3.10,<4.0" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.3,<4.0" },
     { name = "python-dotenv", specifier = ">=1.2,<2.0" },
+    { name = "qrcode", specifier = ">=8.2" },
     { name = "sentry-sdk", extras = ["django"], specifier = ">=2.48.0" },
     { name = "sqlparse", specifier = ">=0.5.4,<1.0" },
     { name = "typing-extensions", specifier = ">=4.15,<5.0" },
@@ -138,6 +153,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/15/75/19762bfc4ea556c303d9af8e36f0cd910ab17dff6c8774644314427a2120/django-6.0.tar.gz", hash = "sha256:7b0c1f50c0759bbe6331c6a39c89ae022a84672674aeda908784617ef47d8e26", size = 10932418, upload-time = "2025-12-03T16:26:21.878Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/ae/f19e24789a5ad852670d6885f5480f5e5895576945fcc01817dfd9bc002a/django-6.0-py3-none-any.whl", hash = "sha256:1cc2c7344303bbfb7ba5070487c17f7fc0b7174bbb0a38cebf03c675f5f19b6d", size = 8339181, upload-time = "2025-12-03T16:26:16.231Z" },
+]
+
+[[package]]
+name = "django-axes"
+version = "8.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asgiref" },
+    { name = "django" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f0/b4/00c701a22d46288e3eb1340a1c141f5b4002572ce836a3e8d069f1e1de8a/django_axes-8.3.1.tar.gz", hash = "sha256:d57e923c0ba33cf45275253dd1313c3a3ff04bec686b38d677beb2b3d43c7bcd", size = 254715, upload-time = "2026-02-11T20:19:52.172Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/f6/777a5df7d5698eeb23c7c496cc268c0181f0489dbc5b5f2b235b30e5d8dd/django_axes-8.3.1-py3-none-any.whl", hash = "sha256:f7887582fd12713064f1602091ff6152752becae5e891a15bf802746cab0f51a", size = 74213, upload-time = "2026-02-11T20:19:48.646Z" },
+]
+
+[[package]]
+name = "django-otp"
+version = "1.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7e/a3/32b6b53ef1026387375e11236255db7c630d9527a2d33fa6529500a880cd/django_otp-1.7.0.tar.gz", hash = "sha256:961ccf2d80a67303cb46d97427b16c476ee075acfa2b4c82a59d8f1e0745a454", size = 75858, upload-time = "2026-01-07T19:57:17.19Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/f0/75ee6cdcf916b7c67dffa87aecdd173e4d68e456839dd53b9313e9cc9201/django_otp-1.7.0-py3-none-any.whl", hash = "sha256:406d2d7f797dc313569270e06d6c360c7d986c9f653eab80b190d663ed5f1133", size = 71331, upload-time = "2026-01-07T19:57:18.655Z" },
 ]
 
 [[package]]
@@ -222,6 +262,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f0/26/19cadc79a718c5edbec86fd4919a6b6d3f681039a2f6d66d14be94e75fb9/python_dotenv-1.2.1.tar.gz", hash = "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6", size = 44221, upload-time = "2025-10-26T15:12:10.434Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/1b/a298b06749107c305e1fe0f814c6c74aea7b2f1e10989cb30f544a1b3253/python_dotenv-1.2.1-py3-none-any.whl", hash = "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61", size = 21230, upload-time = "2025-10-26T15:12:09.109Z" },
+]
+
+[[package]]
+name = "qrcode"
+version = "8.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/b2/7fc2931bfae0af02d5f53b174e9cf701adbb35f39d69c2af63d4a39f81a9/qrcode-8.2.tar.gz", hash = "sha256:35c3f2a4172b33136ab9f6b3ef1c00260dd2f66f858f24d88418a015f446506c", size = 43317, upload-time = "2025-05-01T15:44:24.726Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/b8/d2d6d731733f51684bbf76bf34dab3b70a9148e8f2cef2bb544fccec681a/qrcode-8.2-py3-none-any.whl", hash = "sha256:16e64e0716c14960108e85d853062c9e8bba5ca8252c0b4d0231b9df4060ff4f", size = 45986, upload-time = "2025-05-01T15:44:22.781Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Stacked on `finance/foundation`. Closes `/finance` to everyone but the two of you, and fixes three project-level problems that an authenticated money app makes untenable.

## The access model

Three ordered gates: **authenticated → member of the `finance` group → TOTP-verified in this session.**

The first two failures render the *same* 403. A stranger and a logged-in non-member get byte-identical responses, so having a valid site login tells you nothing about whether a finance app exists behind it. Only the third failure redirects — by then the visitor has proven they hold a household account, so guiding them to the code screen leaks nothing.

The 403 is the page you asked for:

> 🕵️ **Get out of here, nosey!**
> This corner of the site is strictly a two-person operation, and you are not one of the two.

…with a deliberately understated "…unless you live here" link, since you two do need a way in.

## Two-factor

Enrolment shows a QR rendered **inline as SVG**, so the shared secret is never a URL anyone could fetch, plus a manual key for devices that can't scan. The code field uses `inputmode="numeric"` and `autocomplete="one-time-code"` — on iOS the code appears right above the keyboard.

Login is rate-limited by django-axes: five failures locks the (IP, username) pair for 15 minutes and returns 429 with a styled page.

## The three fixes to `datamays/settings.py`

**1. `SECRET_KEY` no longer silently falls back.** It was defaulting to the literal `'fallback-secret-key'` — a string published in this public repo. That key signs session cookies, so anyone could have forged a session. Outside local dev, a missing key is now fatal at boot. Local dev is unaffected.

**2. Sentry no longer receives financial data.** `send_default_pii=True` means request bodies, user identity, and stack-frame locals get attached to every event — for `/finance` that's balances, transaction descriptions, and account identifiers, sitting in a third-party service indefinitely. A `before_send` hook strips all three from finance events while leaving public-site reporting exactly as it was. Tested both directions.

**3. Cookies and transport.** `SESSION_COOKIE_SECURE`, `CSRF_COOKIE_SECURE`, `HttpOnly`, `SameSite=Lax`, and one-year HSTS in production. **HSTS uses `includeSubDomains`** — every current and future `datamays.com` subdomain is then committed to HTTPS, so flag it if that's a problem. I deliberately did *not* enable preload, which is effectively irreversible.

Sessions last 14 days; the second factor is what makes a window that long acceptable on a phone.

## Provisioning

```bash
uv run python manage.py create_finance_user david --first-name David
uv run python manage.py create_finance_user maddie --first-name Maddie
```

Creates the group if needed, prompts for a password (min 12 chars), and adds the user. Each enrols an authenticator app on first sign-in.

## Verification

32 tests, all passing. The ones worth noting:

- An authenticated non-member gets the identical 403 as an anonymous visitor
- A password-only session reaches **none** of the 7 protected routes
- Full enrolment and challenge against **real generated TOTP codes**, not mocks
- A used code cannot be replayed after signing out and back in
- Five bad passwords produce a 429 lockout that refuses even the correct password
- `?next=` cannot bounce a verified session to another host (`//evil.example.com`, `https://…`, `javascript:`, backslash variants)
- Sentry scrubbing removes balances from finance events and leaves `/contact` events intact

Also verified by hand: the `SECRET_KEY` guard raises under `WORKING_ENV=prod` and stays quiet in dev; the 403, login, and QR screens render correctly at 375px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)