### PR TITLE
Finance 11/11: alerts, reports, and scheduled runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ uv run python manage.py test --settings=datamays.settings_test
 > database. The test settings pin the suite to in-memory SQLite and disable
 > Sentry.
 
+### Household Finance
+
+The private finance app lives at `/finance` and is documented in
+[`finance/RUNBOOK.md`](finance/RUNBOOK.md) — setup, Heroku Scheduler jobs, key
+rotation, and what to do when a sync goes wrong.
+
 ### Tailwind / Frontend Dev Server
 
 ```bash

--- a/datamays/settings_test.py
+++ b/datamays/settings_test.py
@@ -9,10 +9,16 @@ Usage:
     uv run python manage.py test --settings=datamays.settings_test
 """
 
-import sentry_sdk
-from cryptography.fernet import Fernet
+import os
 
-from .settings import *  # noqa: F401,F403
+# Cleared before the star-import so settings.py never initialises a real
+# Sentry client — a test run must not report into production error tracking.
+os.environ["SENTRY_DSN"] = ""
+
+import sentry_sdk  # noqa: E402
+from cryptography.fernet import Fernet  # noqa: E402
+
+from .settings import *  # noqa: E402,F401,F403
 
 DATABASES = {
     "default": {

--- a/finance/RUNBOOK.md
+++ b/finance/RUNBOOK.md
@@ -1,0 +1,148 @@
+# Household Finance — runbook
+
+Operating notes for the `finance` app. Written for the version of me that has
+forgotten all of this in eight months.
+
+## First-time setup
+
+### 1. Generate and set the encryption key
+
+Provider credentials are encrypted at rest with this key. **Lose it and every
+connection has to be re-authorized** — the data survives, the credentials do not.
+
+```bash
+uv run python manage.py generate_encryption_key
+```
+
+```bash
+heroku config:set FIELD_ENCRYPTION_KEYS="<the key>" --app datamays
+```
+
+Keep a copy somewhere you'd still have it if Heroku vanished — a password
+manager, not this repo.
+
+### 2. Confirm the other config vars
+
+| Variable | Purpose | Required |
+|---|---|---|
+| `FIELD_ENCRYPTION_KEYS` | Encrypts provider credentials | Yes |
+| `SECRET_KEY` | Signs sessions — the app refuses to boot without it outside dev | Yes |
+| `OPENAI_API_KEY` | Transaction categorisation | No — rules and memos still work without it |
+| `FINANCE_CATEGORISER_MODEL` | Defaults to `gpt-4o-mini` | No |
+| `EMAIL_HOST_USER` / `EMAIL_HOST_PASSWORD` | Alerts and reports | Only if you want email |
+
+### 3. Create the two accounts
+
+```bash
+heroku run python manage.py create_finance_user david --first-name David --email you@example.com --app datamays
+```
+
+Group membership in `finance` is what grants access. Each person enrols an
+authenticator app on first sign-in.
+
+### 4. Seed the categories
+
+```bash
+heroku run python manage.py seed_finance_categories --app datamays
+```
+
+Safe to re-run; it matches on slug and never deletes.
+
+### 5. Connect the institutions
+
+Authorize each one at <https://bridge.simplefin.org/>, then paste the setup
+token at **Settings → Connect an institution**. The app exchanges it, stores it
+encrypted, and pulls 90 days as a test.
+
+Institutions SimpleFIN cannot reach — Northwestern Mutual, CrossCountry
+Mortgage, One Wealth, employer 401(k)s — get a manual account and a CSV import
+instead (**Settings → Imports**).
+
+## Scheduling
+
+Add the Heroku Scheduler add-on, then create exactly two jobs:
+
+| Frequency | Command |
+|---|---|
+| Hourly | `python manage.py finance_hourly` |
+| Daily (pick an early-morning UTC time) | `python manage.py finance_daily` |
+
+**Hourly** syncs day-to-day accounts (checking, savings, money market, credit
+cards), categorises what arrived, rolls up budgets, then evaluates alerts. The
+order matters — alerts must see fresh budget numbers.
+
+**Daily** syncs *everything* including loans and the mortgage, snapshots
+balances so the history charts stay continuous, rolls up budgets, and sends any
+due reports.
+
+Both chains isolate each step: a failed sync still lets budgets roll up from
+the data already present. Both exit non-zero if any step failed, so a broken
+run shows up in `heroku logs` rather than passing silently.
+
+SimpleFIN allows roughly 24 requests a day, which is why the hourly job is
+restricted to accounts that actually move hourly.
+
+## When something looks wrong
+
+**Balances look stale.** The homepage flags accounts that haven't refreshed in
+three days. Check **Settings → Recent syncs**, then the connection's own page
+for the provider's error. `needs_reauth` means the credential was rejected —
+generate a fresh SimpleFIN token and reconnect.
+
+```bash
+heroku run python manage.py sync_accounts --connection <id> --manual --app datamays
+```
+
+**A liability shows the wrong sign.** Some institutions report a debt as
+already-negative rather than as a positive amount owed. Untick
+*"Most institutions report a debt as a positive amount owed"* on that account
+in **Settings → Accounts**. Don't edit data to compensate.
+
+**Transactions aren't categorised.** Check `OPENAI_API_KEY` is set. Without it
+everything still runs — rules and remembered merchants apply — and the rest
+queues in **Activity → needs review**. To re-run:
+
+```bash
+heroku run python manage.py categorize_transactions --app datamays
+```
+
+**A budget looks wrong after editing it.** Editing recomputes the current
+period only. To rebuild history:
+
+```bash
+heroku run python manage.py rollup_budgets --backfill 12 --app datamays
+```
+
+**Alerts are too noisy.** Each alert has a cooldown (default 24h). Budget
+alerts can also gate on how far through the period you are, which is how you
+say "only tell me if we hit 80% before the 15th".
+
+## Rotating the encryption key
+
+Fernet supports multiple keys: the first encrypts, all of them decrypt.
+
+1. Generate a new key.
+2. Set `FIELD_ENCRYPTION_KEYS="<new>,<old>"` — new one first.
+3. Re-save each connection so it re-encrypts under the new key (open and save
+   it in the admin, or re-authorize).
+4. Drop the old key: `FIELD_ENCRYPTION_KEYS="<new>"`.
+
+Skipping step 3 means step 4 makes those credentials unreadable. Settings pages
+still load in that state — deliberately, so you can get in and reconnect — but
+syncing will fail until you do.
+
+## Local development
+
+Always use the test settings for the suite. The repo's `.env` points
+`DATABASE_URL` at the deployed Postgres, so the default settings would run
+tests against production:
+
+```bash
+uv run python manage.py test finance --settings=datamays.settings_test
+```
+
+After changing templates, rebuild the committed CSS — Heroku runs no Node:
+
+```bash
+npm run tailwind:build
+```

--- a/finance/management/commands/finance_daily.py
+++ b/finance/management/commands/finance_daily.py
@@ -1,0 +1,32 @@
+from django.core.management import call_command
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    help = (
+        "The daily chain: sync everything including slow-moving accounts, "
+        "categorise, snapshot balances, roll up budgets, and send due reports."
+    )
+
+    STEPS = [
+        # No high-frequency filter here: this is the run that picks up loans,
+        # the mortgage, and anything the hourly chain skips.
+        ("sync_accounts", {}),
+        ("categorize_transactions", {}),
+        ("snapshot_balances", {}),
+        ("rollup_budgets", {}),
+        ("send_reports", {}),
+    ]
+
+    def handle(self, *args, **options):
+        failures = []
+
+        for name, kwargs in self.STEPS:
+            try:
+                call_command(name, verbosity=options["verbosity"], **kwargs)
+            except Exception as exc:  # noqa: BLE001
+                failures.append(f"{name}: {exc}")
+                self.stderr.write(self.style.ERROR(f"{name} failed: {exc}"))
+
+        if failures:
+            raise SystemExit(1)

--- a/finance/management/commands/finance_hourly.py
+++ b/finance/management/commands/finance_hourly.py
@@ -1,0 +1,35 @@
+from django.core.management import call_command
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    help = (
+        "The hourly chain: sync day-to-day accounts, categorise what arrived, "
+        "roll up budgets, then evaluate alerts. Wired to Heroku Scheduler."
+    )
+
+    # Order matters: alerts must see freshly rolled-up budgets, and budgets
+    # must see freshly categorised transactions.
+    STEPS = [
+        ("sync_accounts", {"high_frequency_only": True}),
+        ("categorize_transactions", {}),
+        ("rollup_budgets", {}),
+        ("send_alerts", {}),
+    ]
+
+    def handle(self, *args, **options):
+        failures = []
+
+        for name, kwargs in self.STEPS:
+            try:
+                call_command(name, verbosity=options["verbosity"], **kwargs)
+            except Exception as exc:  # noqa: BLE001
+                # A failing sync should not stop budgets being rolled up from
+                # the data already present, so each step is isolated.
+                failures.append(f"{name}: {exc}")
+                self.stderr.write(self.style.ERROR(f"{name} failed: {exc}"))
+
+        if failures:
+            # Non-zero exit so a broken chain is visible in Heroku's logs
+            # rather than passing silently.
+            raise SystemExit(1)

--- a/finance/management/commands/send_alerts.py
+++ b/finance/management/commands/send_alerts.py
@@ -1,0 +1,23 @@
+from django.core.management.base import BaseCommand
+
+from finance.services.alerts import evaluate_alerts
+
+
+class Command(BaseCommand):
+    help = "Evaluate active alerts and email any that have newly breached."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Evaluate and record events without sending email.",
+        )
+
+    def handle(self, *args, **options):
+        fired = evaluate_alerts(send=not options["dry_run"])
+
+        if options["verbosity"]:
+            if not fired:
+                self.stdout.write("No alerts fired.")
+            for event in fired:
+                self.stdout.write(self.style.WARNING(f"{event.alert.name}: {event.message.splitlines()[0]}"))

--- a/finance/management/commands/send_reports.py
+++ b/finance/management/commands/send_reports.py
@@ -1,0 +1,25 @@
+from django.core.management.base import BaseCommand
+
+from finance.models import ReportCadence
+from finance.services.reports import send_due_reports
+
+
+class Command(BaseCommand):
+    help = "Send any scheduled reports that are due today."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--cadence",
+            choices=[value for value, _ in ReportCadence.choices],
+            help="Only consider reports of this cadence.",
+        )
+
+    def handle(self, *args, **options):
+        sent = send_due_reports(cadence=options.get("cadence"))
+
+        if options["verbosity"]:
+            self.stdout.write(
+                self.style.SUCCESS(f"Sent {len(sent)} report(s).")
+                if sent
+                else "No reports due."
+            )

--- a/finance/services/alerts.py
+++ b/finance/services/alerts.py
@@ -1,0 +1,224 @@
+"""Evaluating alerts and sending them.
+
+Two things matter more than the arithmetic here.
+
+**Cooldowns.** The hourly run re-evaluates every alert, so without a cooldown a
+breached threshold would email once an hour until it stopped being breached.
+An alert people mute is worse than no alert.
+
+**Honesty about staleness.** An alert derived from a balance that has not
+refreshed in days is a guess. Those are still sent — silence would be worse —
+but they say so.
+"""
+
+import logging
+from decimal import Decimal
+
+from django.conf import settings
+from django.core.mail import send_mail
+from django.utils import timezone
+
+from ..models import Alert, AlertEvent, AlertKind, BudgetPeriod, Comparison
+from ..periods import elapsed_fraction
+
+logger = logging.getLogger(__name__)
+
+
+def observed_value(alert):
+    """The number this alert watches, or None when it cannot be read."""
+    if alert.kind == AlertKind.ACCOUNT_BALANCE:
+        if alert.account is None or alert.account.current_balance is None:
+            return None
+
+        # Compared as a magnitude so "card above $2,000" means what a person
+        # means, rather than depending on the storage sign.
+        return (
+            abs(alert.account.current_balance)
+            if alert.account.is_liability
+            else alert.account.current_balance
+        )
+
+    period = current_period_for(alert.budget)
+
+    if period is None:
+        return None
+
+    if alert.kind == AlertKind.BUDGET_AMOUNT:
+        return period.actual_amount
+
+    if not period.target_amount:
+        return None
+
+    return (period.actual_amount / period.target_amount) * 100
+
+
+def current_period_for(budget):
+    if budget is None:
+        return None
+
+    today = timezone.localdate()
+
+    return BudgetPeriod.objects.filter(
+        budget=budget, period_start__lte=today, period_end__gte=today
+    ).first()
+
+
+def is_breached(alert, value):
+    if value is None:
+        return False
+
+    if alert.comparison == Comparison.ABOVE:
+        return value > alert.threshold
+
+    return value < alert.threshold
+
+
+def is_in_cooldown(alert, now=None):
+    if alert.last_triggered_at is None:
+        return False
+
+    now = now or timezone.now()
+    elapsed_hours = (now - alert.last_triggered_at).total_seconds() / 3600
+
+    return elapsed_hours < alert.cooldown_hours
+
+
+def period_gate_passed(alert):
+    """Whether a budget alert's "only after N% of the period" gate is met.
+
+    This is what makes "80% of the grocery budget before the 15th" expressible:
+    the same spend is unremarkable late in a period and worth knowing about
+    early.
+    """
+    if alert.only_after_period_fraction is None:
+        return True
+
+    period = current_period_for(alert.budget)
+
+    if period is None:
+        return False
+
+    elapsed = elapsed_fraction(
+        period.period_start, period.period_end, timezone.localdate()
+    )
+
+    return elapsed >= alert.only_after_period_fraction
+
+
+def build_message(alert, value):
+    if alert.kind == AlertKind.ACCOUNT_BALANCE:
+        direction = "risen above" if alert.comparison == Comparison.ABOVE else "fallen below"
+        message = (
+            f"{alert.account.name} has {direction} ${alert.threshold:,.2f}. "
+            f"It is currently ${value:,.2f}."
+        )
+
+        if _is_stale(alert.account):
+            message += (
+                "\n\nNote: this balance has not refreshed recently, so it may "
+                "be out of date."
+            )
+
+        return message
+
+    period = current_period_for(alert.budget)
+
+    if alert.kind == AlertKind.BUDGET_PERCENT:
+        headline = (
+            f"{alert.budget.name} is at {value:.0f}% of its "
+            f"${period.target_amount:,.0f} target."
+        )
+    else:
+        headline = (
+            f"{alert.budget.name} has reached ${value:,.2f} "
+            f"of its ${period.target_amount:,.0f} target."
+        )
+
+    pace = period.pace_difference()
+    pacing = (
+        f"That is ${pace:,.0f} ahead of an even pace"
+        if pace > 0
+        else f"That is ${abs(pace):,.0f} behind an even pace"
+    )
+
+    return (
+        f"{headline}\n\n{pacing}, with the period running to "
+        f"{period.period_end:%-d %B}."
+    )
+
+
+def _is_stale(account, days=3):
+    if account.is_manual or account.balance_as_of is None:
+        return False
+
+    return (timezone.now() - account.balance_as_of).days >= days
+
+
+def evaluate_alerts(*, send=True, now=None):
+    """Check every active alert. Returns the events that fired."""
+    now = now or timezone.now()
+    fired = []
+
+    alerts = Alert.objects.filter(is_active=True).select_related(
+        "account", "budget", "user"
+    )
+
+    for alert in alerts:
+        value = observed_value(alert)
+
+        if not is_breached(alert, value):
+            continue
+
+        if not period_gate_passed(alert):
+            continue
+
+        if is_in_cooldown(alert, now):
+            continue
+
+        event = AlertEvent.objects.create(
+            alert=alert,
+            observed_value=Decimal(str(round(float(value), 2))),
+            message=build_message(alert, value),
+        )
+
+        if send:
+            deliver(event)
+
+        alert.last_triggered_at = now
+        alert.save(update_fields=["last_triggered_at", "updated_at"])
+
+        fired.append(event)
+
+    return fired
+
+
+def deliver(event):
+    """Email one alert. Delivery failures are recorded, never raised.
+
+    A mail outage must not stop the remaining alerts from being evaluated.
+    """
+    recipient = event.alert.user.email
+
+    if not recipient:
+        event.delivery_error = "No email address on this account."
+        event.save(update_fields=["delivery_error"])
+        return False
+
+    try:
+        send_mail(
+            subject=f"[Household Finance] {event.alert.name}",
+            message=event.message,
+            from_email=settings.DEFAULT_FROM_EMAIL,
+            recipient_list=[recipient],
+            fail_silently=False,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("Could not deliver alert %s", event.alert_id)
+        event.delivery_error = str(exc)[:500]
+        event.save(update_fields=["delivery_error"])
+        return False
+
+    event.was_delivered = True
+    event.save(update_fields=["was_delivered"])
+
+    return True

--- a/finance/services/alerts.py
+++ b/finance/services/alerts.py
@@ -18,6 +18,7 @@ from django.conf import settings
 from django.core.mail import send_mail
 from django.utils import timezone
 
+from ..dates import household_today
 from ..models import Alert, AlertEvent, AlertKind, BudgetPeriod, Comparison
 from ..periods import elapsed_fraction
 
@@ -56,7 +57,7 @@ def current_period_for(budget):
     if budget is None:
         return None
 
-    today = timezone.localdate()
+    today = household_today()
 
     return BudgetPeriod.objects.filter(
         budget=budget, period_start__lte=today, period_end__gte=today
@@ -99,7 +100,7 @@ def period_gate_passed(alert):
         return False
 
     elapsed = elapsed_fraction(
-        period.period_start, period.period_end, timezone.localdate()
+        period.period_start, period.period_end, household_today()
     )
 
     return elapsed >= alert.only_after_period_fraction
@@ -177,7 +178,8 @@ def evaluate_alerts(*, send=True, now=None):
 
         event = AlertEvent.objects.create(
             alert=alert,
-            observed_value=Decimal(str(round(float(value), 2))),
+            # Quantised, never routed through float — see models.base.
+            observed_value=Decimal(value).quantize(Decimal("0.01")),
             message=build_message(alert, value),
         )
 

--- a/finance/services/reports.py
+++ b/finance/services/reports.py
@@ -14,6 +14,7 @@ from django.conf import settings
 from django.core.mail import send_mail
 from django.utils import timezone
 
+from ..dates import household_today, to_household_date
 from ..models import (
     Account,
     BudgetPeriod,
@@ -37,7 +38,7 @@ DEFAULT_SECTIONS = ["balances", "budgets", "spend"]
 
 
 def window_for(report, on_date=None):
-    on_date = on_date or timezone.localdate()
+    on_date = on_date or household_today()
 
     if report.cadence == ReportCadence.WEEKLY:
         return on_date - timedelta(days=7), on_date
@@ -54,7 +55,7 @@ def is_due(report, on_date=None, now=None):
     if not report.is_active:
         return False
 
-    on_date = on_date or timezone.localdate()
+    on_date = on_date or household_today()
     now = now or timezone.now()
 
     if report.cadence == ReportCadence.WEEKLY:
@@ -67,7 +68,7 @@ def is_due(report, on_date=None, now=None):
     if report.last_sent_at is None:
         return True
 
-    return timezone.localtime(report.last_sent_at).date() < on_date
+    return to_household_date(report.last_sent_at) < on_date
 
 
 def _accounts_for(report):

--- a/finance/services/reports.py
+++ b/finance/services/reports.py
@@ -1,0 +1,205 @@
+"""Weekly and monthly email summaries.
+
+Sections are chosen per report, so one person can get a full picture and the
+other just the budgets. Rendered as plain text: these arrive on phones, and a
+summary that reads cleanly in a notification preview beats one that needs
+images loaded to make sense.
+"""
+
+import logging
+from datetime import timedelta
+from decimal import Decimal
+
+from django.conf import settings
+from django.core.mail import send_mail
+from django.utils import timezone
+
+from ..models import (
+    Account,
+    BudgetPeriod,
+    ReportCadence,
+    ScheduledReport,
+    Transaction,
+)
+from .analytics import spend_by_category
+
+logger = logging.getLogger(__name__)
+
+SECTION_CHOICES = [
+    ("balances", "Account balances"),
+    ("budgets", "Budget attainment"),
+    ("spend", "Spend by category"),
+    ("transactions", "Largest transactions"),
+    ("review", "Transactions needing review"),
+]
+
+DEFAULT_SECTIONS = ["balances", "budgets", "spend"]
+
+
+def window_for(report, on_date=None):
+    on_date = on_date or timezone.localdate()
+
+    if report.cadence == ReportCadence.WEEKLY:
+        return on_date - timedelta(days=7), on_date
+
+    return on_date - timedelta(days=30), on_date
+
+
+def is_due(report, on_date=None, now=None):
+    """Whether this report should go out today.
+
+    Guards on both the calendar day and the last send, so a second run on the
+    same day — a retry, a manual invocation — does not send twice.
+    """
+    if not report.is_active:
+        return False
+
+    on_date = on_date or timezone.localdate()
+    now = now or timezone.now()
+
+    if report.cadence == ReportCadence.WEEKLY:
+        # isoweekday: Monday is 1, matching send_day.
+        if on_date.isoweekday() != report.send_day:
+            return False
+    elif on_date.day != report.send_day:
+        return False
+
+    if report.last_sent_at is None:
+        return True
+
+    return timezone.localtime(report.last_sent_at).date() < on_date
+
+
+def _accounts_for(report):
+    accounts = Account.objects.filter(is_active=True).select_related("institution")
+
+    if report.account_ids:
+        accounts = accounts.filter(pk__in=report.account_ids)
+
+    return accounts
+
+
+def build_sections(report, start, end):
+    chosen = report.sections or DEFAULT_SECTIONS
+    blocks = []
+
+    if "balances" in chosen:
+        accounts = list(_accounts_for(report))
+        lines = [
+            f"  {account.name}: ${account.display_balance:,.2f}"
+            for account in accounts
+            if account.display_balance is not None
+        ]
+        net_worth = sum(
+            (a.current_balance or Decimal("0") for a in accounts if a.include_in_net_worth),
+            Decimal("0"),
+        )
+        lines.append(f"  ---\n  Net worth: ${net_worth:,.2f}")
+        blocks.append(("Balances", "\n".join(lines)))
+
+    if "budgets" in chosen:
+        periods = BudgetPeriod.objects.filter(
+            budget__is_active=True, period_start__lte=end, period_end__gte=end
+        ).select_related("budget")
+
+        if report.budget_ids:
+            periods = periods.filter(budget_id__in=report.budget_ids)
+
+        lines = []
+
+        for period in periods:
+            state = "OVER" if period.is_over else "ok"
+            lines.append(
+                f"  {period.budget.name}: ${period.actual_amount:,.0f} of "
+                f"${period.target_amount:,.0f} ({state})"
+            )
+
+        blocks.append(("Budgets", "\n".join(lines) or "  No active budgets."))
+
+    if "spend" in chosen:
+        breakdown = spend_by_category(start, end, account_ids=report.account_ids or None, limit=6)
+        lines = [
+            f"  {label}: ${value:,.0f}"
+            for label, value in zip(breakdown["labels"], breakdown["values"])
+        ]
+        lines.append(f"  ---\n  Total: ${breakdown['total']:,.0f}")
+        blocks.append(("Spend", "\n".join(lines)))
+
+    if "transactions" in chosen:
+        largest = (
+            Transaction.objects.filter(
+                posted_on__gte=start, posted_on__lte=end, is_transfer=False, amount__lt=0
+            )
+            .select_related("account")
+            .order_by("amount")[:8]
+        )
+        lines = [
+            f"  {t.posted_on:%-d %b}  ${t.display_amount:,.2f}  {t.description_raw[:44]}"
+            for t in largest
+        ]
+        blocks.append(("Largest transactions", "\n".join(lines) or "  None."))
+
+    if "review" in chosen:
+        count = Transaction.objects.filter(needs_review=True).count()
+        blocks.append(
+            (
+                "Needs review",
+                f"  {count} transaction{'s' if count != 1 else ''} waiting to be categorised."
+                if count
+                else "  Nothing waiting.",
+            )
+        )
+
+    return blocks
+
+
+def render_report(report, start, end):
+    blocks = build_sections(report, start, end)
+
+    body = [
+        f"Household Finance — {report.get_cadence_display().lower()} summary",
+        f"{start:%-d %B} to {end:%-d %B %Y}",
+        "",
+    ]
+
+    for title, content in blocks:
+        body.extend([title.upper(), content, ""])
+
+    body.append("Sent by datamays.com/finance")
+
+    return "\n".join(body)
+
+
+def send_report(report, on_date=None):
+    start, end = window_for(report, on_date)
+    recipient = report.user.email
+
+    if not recipient:
+        logger.warning("Report %s has no recipient address", report.pk)
+        return False
+
+    try:
+        send_mail(
+            subject=f"[Household Finance] {report.name}",
+            message=render_report(report, start, end),
+            from_email=settings.DEFAULT_FROM_EMAIL,
+            recipient_list=[recipient],
+            fail_silently=False,
+        )
+    except Exception:  # noqa: BLE001
+        logger.exception("Could not send report %s", report.pk)
+        return False
+
+    report.last_sent_at = timezone.now()
+    report.save(update_fields=["last_sent_at", "updated_at"])
+
+    return True
+
+
+def send_due_reports(on_date=None, *, cadence=None):
+    reports = ScheduledReport.objects.filter(is_active=True).select_related("user")
+
+    if cadence:
+        reports = reports.filter(cadence=cadence)
+
+    return [report for report in reports if is_due(report, on_date) and send_report(report, on_date)]

--- a/finance/templates/finance/alerts/confirm_delete.html
+++ b/finance/templates/finance/alerts/confirm_delete.html
@@ -1,0 +1,16 @@
+{% extends "finance/base_finance.html" %}
+
+{% block finance_content %}
+<h1 class="text-2xl font-extrabold tracking-tight md:text-3xl">Delete alert</h1>
+
+<div class="mt-6 max-w-lg rounded-card border border-error/40 bg-error/5 p-6">
+  <p class="text-text-secondary">Delete <span class="font-semibold text-text-primary">{{ alert.name }}</span>?</p>
+
+  <form method="post" class="mt-6 flex flex-col gap-3 sm:flex-row">
+    {% csrf_token %}
+    <button type="submit" class="rounded-button bg-error px-6 py-3 font-medium text-white transition hover:opacity-90">Delete it</button>
+    <a href="{% url 'finance:alerts' %}"
+       class="rounded-button border border-border px-6 py-3 text-center font-medium text-text-secondary transition hover:bg-muted">Keep it</a>
+  </form>
+</div>
+{% endblock %}

--- a/finance/templates/finance/alerts/form.html
+++ b/finance/templates/finance/alerts/form.html
@@ -1,0 +1,40 @@
+{% extends "finance/base_finance.html" %}
+
+{% block finance_content %}
+<h1 class="text-2xl font-extrabold tracking-tight md:text-3xl">{{ page_title }}</h1>
+
+{% include "finance/partials/messages.html" %}
+
+<form method="post" class="mt-8 max-w-lg space-y-5">
+  {% csrf_token %}
+
+  {% if form.non_field_errors %}
+    <div class="rounded-button border border-error/40 bg-error/10 px-4 py-3 text-sm text-error" role="alert">
+      {% for error in form.non_field_errors %}<p>{{ error }}</p>{% endfor %}
+    </div>
+  {% endif %}
+
+  {% for field in form %}
+    <div>
+      {% if field.field.widget.input_type == 'checkbox' %}
+        <label class="flex items-center gap-3 text-sm font-medium">{{ field }} <span>{{ field.label }}</span></label>
+      {% else %}
+        <label for="{{ field.id_for_label }}" class="mb-1.5 block text-sm font-medium">{{ field.label }}</label>
+        {{ field }}
+        {% if field.help_text %}<p class="mt-1.5 text-xs text-text-muted">{{ field.help_text }}</p>{% endif %}
+      {% endif %}
+      {% if field.errors %}<p class="mt-1.5 text-sm text-error">{{ field.errors.0 }}</p>{% endif %}
+    </div>
+  {% endfor %}
+
+  <div class="flex flex-col gap-3 sm:flex-row">
+    <button type="submit" class="rounded-button bg-primary px-6 py-3 font-medium text-white transition hover:bg-primary-600">Save alert</button>
+    <a href="{% url 'finance:alerts' %}"
+       class="rounded-button border border-border px-6 py-3 text-center font-medium text-text-secondary transition hover:bg-muted">Cancel</a>
+    {% if form.instance.pk %}
+      <a href="{% url 'finance:alert_delete' form.instance.pk %}"
+         class="rounded-button px-6 py-3 text-center font-medium text-error transition hover:bg-error/10">Delete</a>
+    {% endif %}
+  </div>
+</form>
+{% endblock %}

--- a/finance/templates/finance/alerts/list.html
+++ b/finance/templates/finance/alerts/list.html
@@ -1,0 +1,64 @@
+{% extends "finance/base_finance.html" %}
+{% load finance_extras %}
+
+{% block finance_content %}
+<h1 class="text-2xl font-extrabold tracking-tight md:text-3xl">Alerts &amp; reports</h1>
+<p class="mt-2 text-text-secondary">Yours alone — {{ request.user.first_name|default:request.user.username }}'s thresholds, to your inbox.</p>
+
+{% include "finance/partials/messages.html" %}
+
+<section class="mt-8">
+  <div class="flex items-center justify-between gap-3">
+    <h2 class="text-sm font-semibold uppercase tracking-wide text-text-muted">Alerts</h2>
+    <a href="{% url 'finance:alert_create' %}"
+       class="rounded-button bg-primary px-3.5 py-2 text-xs font-medium text-white transition hover:bg-primary-600">New alert</a>
+  </div>
+
+  <div class="mt-3 space-y-2">
+    {% for alert in alerts %}
+      <a href="{% url 'finance:alert_edit' alert.pk %}"
+         class="block rounded-card border border-border bg-surface p-4 transition hover:border-primary/50 {% if not alert.is_active %}opacity-50{% endif %}">
+        <div class="flex items-center justify-between gap-3">
+          <div class="min-w-0">
+            <p class="truncate font-medium">{{ alert.name }}</p>
+            <p class="mt-0.5 text-xs text-text-muted">
+              {% if alert.account %}{{ alert.account.name }}{% else %}{{ alert.budget.name }}{% endif %} ·
+              {{ alert.get_comparison_display|lower }} {{ alert.threshold|money:0 }}{% if alert.kind == 'budget_percent' %}%{% endif %}
+              {% if alert.last_triggered_at %}· last fired {{ alert.last_triggered_at|timesince }} ago{% endif %}
+            </p>
+          </div>
+        </div>
+      </a>
+    {% empty %}
+      <div class="rounded-card border border-dashed border-border bg-surface/50 p-6 text-center">
+        <p class="text-sm text-text-secondary">No alerts yet.</p>
+      </div>
+    {% endfor %}
+  </div>
+</section>
+
+<section class="mt-8">
+  <div class="flex items-center justify-between gap-3">
+    <h2 class="text-sm font-semibold uppercase tracking-wide text-text-muted">Scheduled reports</h2>
+    <a href="{% url 'finance:report_create' %}"
+       class="rounded-button bg-primary px-3.5 py-2 text-xs font-medium text-white transition hover:bg-primary-600">New report</a>
+  </div>
+
+  <div class="mt-3 space-y-2">
+    {% for report in reports %}
+      <a href="{% url 'finance:report_edit' report.pk %}"
+         class="block rounded-card border border-border bg-surface p-4 transition hover:border-primary/50 {% if not report.is_active %}opacity-50{% endif %}">
+        <p class="truncate font-medium">{{ report.name }}</p>
+        <p class="mt-0.5 text-xs text-text-muted">
+          {{ report.get_cadence_display }}
+          {% if report.last_sent_at %}· last sent {{ report.last_sent_at|timesince }} ago{% else %}· never sent{% endif %}
+        </p>
+      </a>
+    {% empty %}
+      <div class="rounded-card border border-dashed border-border bg-surface/50 p-6 text-center">
+        <p class="text-sm text-text-secondary">No reports scheduled.</p>
+      </div>
+    {% endfor %}
+  </div>
+</section>
+{% endblock %}

--- a/finance/templates/finance/alerts/report_form.html
+++ b/finance/templates/finance/alerts/report_form.html
@@ -1,0 +1,47 @@
+{% extends "finance/base_finance.html" %}
+
+{% block finance_content %}
+<h1 class="text-2xl font-extrabold tracking-tight md:text-3xl">{{ page_title }}</h1>
+
+{% include "finance/partials/messages.html" %}
+
+<form method="post" class="mt-8 max-w-lg space-y-5">
+  {% csrf_token %}
+
+  {% for field in form %}
+    {% if field.name != 'sections_selected' %}
+      <div>
+        {% if field.field.widget.input_type == 'checkbox' %}
+          <label class="flex items-center gap-3 text-sm font-medium">{{ field }} <span>{{ field.label }}</span></label>
+        {% else %}
+          <label for="{{ field.id_for_label }}" class="mb-1.5 block text-sm font-medium">{{ field.label }}</label>
+          {{ field }}
+          {% if field.help_text %}<p class="mt-1.5 text-xs text-text-muted">{{ field.help_text }}</p>{% endif %}
+        {% endif %}
+        {% if field.errors %}<p class="mt-1.5 text-sm text-error">{{ field.errors.0 }}</p>{% endif %}
+      </div>
+    {% endif %}
+  {% endfor %}
+
+  <fieldset class="rounded-card border border-border bg-surface p-4">
+    <legend class="px-1 text-sm font-medium">{{ form.sections_selected.label }}</legend>
+    <div class="mt-2 space-y-2.5">
+      {% for choice in form.sections_selected %}
+        <label class="flex items-center gap-3 text-sm text-text-secondary">{{ choice.tag }} <span>{{ choice.choice_label }}</span></label>
+      {% endfor %}
+    </div>
+  </fieldset>
+
+  <div class="flex flex-col gap-3 sm:flex-row">
+    <button type="submit" class="rounded-button bg-primary px-6 py-3 font-medium text-white transition hover:bg-primary-600">Save report</button>
+    {% if form.instance.pk %}
+      <button type="submit" name="action" value="send_test"
+              class="rounded-button border border-border px-6 py-3 font-medium text-text-secondary transition hover:bg-muted">
+        Send me one now
+      </button>
+    {% endif %}
+    <a href="{% url 'finance:alerts' %}"
+       class="rounded-button px-6 py-3 text-center font-medium text-text-muted transition hover:bg-muted">Cancel</a>
+  </div>
+</form>
+{% endblock %}

--- a/finance/templates/finance/partials/header.html
+++ b/finance/templates/finance/partials/header.html
@@ -37,6 +37,8 @@
            class="absolute right-0 mt-2 w-52 overflow-hidden rounded-card border border-border bg-surface py-1 shadow-xl">
         <a href="{% url 'finance:settings' %}" role="menuitem"
            class="block px-4 py-2.5 text-sm text-text-secondary transition hover:bg-muted hover:text-text-primary">Settings</a>
+        <a href="{% url 'finance:alerts' %}" role="menuitem"
+           class="block px-4 py-2.5 text-sm text-text-secondary transition hover:bg-muted hover:text-text-primary">Alerts &amp; reports</a>
         <a href="{% url 'finance:preferences' %}" role="menuitem"
            class="block px-4 py-2.5 text-sm text-text-secondary transition hover:bg-muted hover:text-text-primary">Preferences</a>
         <a href="{% url 'core:home' %}" role="menuitem"

--- a/finance/tests/test_alerts_reports.py
+++ b/finance/tests/test_alerts_reports.py
@@ -12,6 +12,7 @@ from django.core.management import call_command
 from django.test import TestCase
 from django.utils import timezone
 
+from finance.dates import household_today
 from finance.models import (
     Account,
     AccountConnection,
@@ -65,7 +66,7 @@ class AlertTestCase(TestCase):
         self.groceries = Category.objects.get(slug="food-groceries")
 
     def make_budget_period(self, actual="600.00", target="800.00", name="Groceries"):
-        today = timezone.localdate()
+        today = household_today()
         budget = Budget.objects.create(name=name, amount=Decimal(target))
         budget.categories.set([self.groceries])
 
@@ -232,8 +233,8 @@ class BudgetAlertTests(AlertTestCase):
             only_after_period_fraction=0.0,
         )
 
-        period.period_start = timezone.localdate() - timedelta(days=1)
-        period.period_end = timezone.localdate() + timedelta(days=200)
+        period.period_start = household_today() - timedelta(days=1)
+        period.period_end = household_today() + timedelta(days=200)
         period.save()
 
         # Barely into a long period, so the gate at 0.0 still passes.
@@ -252,8 +253,8 @@ class BudgetAlertTests(AlertTestCase):
             only_after_period_fraction=0.9,
         )
 
-        period.period_start = timezone.localdate()
-        period.period_end = timezone.localdate() + timedelta(days=60)
+        period.period_start = household_today()
+        period.period_end = household_today() + timedelta(days=60)
         period.save()
 
         self.assertEqual(evaluate_alerts(), [])
@@ -310,7 +311,7 @@ class ReportTests(AlertTestCase):
         kwargs.setdefault("name", "Weekly summary")
         kwargs.setdefault("cadence", ReportCadence.WEEKLY)
         kwargs.setdefault("sections", ["balances", "budgets", "spend"])
-        kwargs.setdefault("send_day", timezone.localdate().isoweekday())
+        kwargs.setdefault("send_day", household_today().isoweekday())
 
         return ScheduledReport.objects.create(user=self.user, **kwargs)
 
@@ -329,7 +330,7 @@ class ReportTests(AlertTestCase):
         self.assertIsNotNone(report.last_sent_at)
 
     def test_a_report_due_another_day_is_not_sent(self):
-        other_day = (timezone.localdate().isoweekday() % 7) + 1
+        other_day = (household_today().isoweekday() % 7) + 1
         self.make_report(send_day=other_day)
 
         self.assertEqual(report_service.send_due_reports(), [])
@@ -368,7 +369,7 @@ class ReportTests(AlertTestCase):
         self.assertEqual(report_service.send_due_reports(), [])
 
     def test_a_monthly_report_is_due_on_its_day_of_month(self):
-        today = timezone.localdate()
+        today = household_today()
         report = self.make_report(
             cadence=ReportCadence.MONTHLY, send_day=min(today.day, 28)
         )
@@ -524,3 +525,25 @@ class AlertUIScopingTests(AlertTestCase):
         fired = evaluate_alerts()
 
         self.assertEqual({event.alert.name for event in fired}, {"Mine"})
+
+
+class AlertPrecisionTests(AlertTestCase):
+    """Money must never round-trip through float."""
+
+    def test_the_observed_value_keeps_decimal_precision(self):
+        self.checking.current_balance = Decimal("1234.56")
+        self.checking.save()
+
+        Alert.objects.create(
+            user=self.user,
+            name="Balance",
+            kind=AlertKind.ACCOUNT_BALANCE,
+            account=self.checking,
+            comparison=Comparison.ABOVE,
+            threshold=Decimal("1000.00"),
+        )
+
+        fired = evaluate_alerts(send=False)
+
+        self.assertEqual(fired[0].observed_value, Decimal("1234.56"))
+        self.assertIsInstance(fired[0].observed_value, Decimal)

--- a/finance/tests/test_alerts_reports.py
+++ b/finance/tests/test_alerts_reports.py
@@ -1,0 +1,526 @@
+"""Alerts and scheduled reports.
+
+Email is captured by Django's locmem backend; nothing leaves the test process.
+"""
+
+from datetime import date, timedelta
+from decimal import Decimal
+from unittest.mock import patch
+
+from django.core import mail
+from django.core.management import call_command
+from django.test import TestCase
+from django.utils import timezone
+
+from finance.models import (
+    Account,
+    AccountConnection,
+    AccountType,
+    Alert,
+    AlertEvent,
+    AlertKind,
+    Budget,
+    BudgetPeriod,
+    Category,
+    Comparison,
+    ReportCadence,
+    ScheduledReport,
+)
+from finance.services.alerts import evaluate_alerts
+from finance.services import alerts as alert_service
+from finance.services import reports as report_service
+
+from .factories import make_account, make_institution, make_transaction
+from .test_access import make_user
+
+
+class AlertTestCase(TestCase):
+    def setUp(self):
+        call_command("seed_finance_categories", verbosity=0)
+
+        self.user = make_user("david")
+        self.user.email = "david@example.com"
+        self.user.save()
+
+        self.institution = make_institution()
+        self.connection = AccountConnection.objects.create(
+            institution=self.institution, label="Byline", access_secret="x"
+        )
+        self.checking = make_account(
+            self.institution,
+            name="Checking",
+            connection=self.connection,
+            current_balance=Decimal("250.00"),
+            balance_as_of=timezone.now(),
+        )
+        self.card = make_account(
+            self.institution,
+            name="Card",
+            account_type=AccountType.CREDIT_CARD,
+            connection=self.connection,
+            current_balance=Decimal("-2400.00"),
+            balance_as_of=timezone.now(),
+        )
+
+        self.groceries = Category.objects.get(slug="food-groceries")
+
+    def make_budget_period(self, actual="600.00", target="800.00", name="Groceries"):
+        today = timezone.localdate()
+        budget = Budget.objects.create(name=name, amount=Decimal(target))
+        budget.categories.set([self.groceries])
+
+        period = BudgetPeriod.objects.create(
+            budget=budget,
+            period_start=today.replace(day=1),
+            period_end=today.replace(day=28),
+            target_amount=Decimal(target),
+            actual_amount=Decimal(actual),
+        )
+
+        return budget, period
+
+
+class BalanceAlertTests(AlertTestCase):
+    def make_alert(self, **kwargs):
+        kwargs.setdefault("name", "Checking running low")
+        kwargs.setdefault("kind", AlertKind.ACCOUNT_BALANCE)
+        kwargs.setdefault("account", self.checking)
+        kwargs.setdefault("comparison", Comparison.BELOW)
+        kwargs.setdefault("threshold", Decimal("500.00"))
+
+        return Alert.objects.create(user=self.user, **kwargs)
+
+    def test_a_breached_threshold_fires_and_emails(self):
+        self.make_alert()
+
+        fired = evaluate_alerts()
+
+        self.assertEqual(len(fired), 1)
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertIn("Checking", mail.outbox[0].body)
+        self.assertTrue(fired[0].was_delivered)
+
+    def test_an_unbreached_threshold_stays_quiet(self):
+        self.make_alert(threshold=Decimal("100.00"))
+
+        self.assertEqual(evaluate_alerts(), [])
+        self.assertEqual(len(mail.outbox), 0)
+
+    def test_a_card_balance_is_compared_as_an_amount_owed(self):
+        # Stored negative for net worth; "above $2,000" should mean owing more.
+        self.make_alert(
+            name="Card too high",
+            account=self.card,
+            comparison=Comparison.ABOVE,
+            threshold=Decimal("2000.00"),
+        )
+
+        fired = evaluate_alerts()
+
+        self.assertEqual(len(fired), 1)
+        self.assertEqual(fired[0].observed_value, Decimal("2400.00"))
+
+    def test_the_cooldown_prevents_hourly_repeats(self):
+        self.make_alert()
+
+        evaluate_alerts()
+        evaluate_alerts()
+        evaluate_alerts()
+
+        # Otherwise the hourly chain would email every hour until fixed, and
+        # an alert people mute is worse than no alert.
+        self.assertEqual(len(mail.outbox), 1)
+
+    def test_it_fires_again_once_the_cooldown_expires(self):
+        alert = self.make_alert(cooldown_hours=1)
+        evaluate_alerts()
+
+        alert.last_triggered_at = timezone.now() - timedelta(hours=2)
+        alert.save()
+
+        evaluate_alerts()
+
+        self.assertEqual(len(mail.outbox), 2)
+
+    def test_inactive_alerts_are_skipped(self):
+        self.make_alert(is_active=False)
+
+        self.assertEqual(evaluate_alerts(), [])
+
+    def test_a_stale_balance_is_flagged_in_the_message(self):
+        self.checking.balance_as_of = timezone.now() - timedelta(days=5)
+        self.checking.save()
+        self.make_alert()
+
+        evaluate_alerts()
+
+        self.assertIn("may be out of date", mail.outbox[0].body)
+
+    def test_an_account_with_no_balance_does_not_fire(self):
+        self.checking.current_balance = None
+        self.checking.save()
+        self.make_alert()
+
+        self.assertEqual(evaluate_alerts(), [])
+
+    def test_a_mail_failure_is_recorded_not_raised(self):
+        self.make_alert()
+
+        with patch("finance.services.alerts.send_mail", side_effect=OSError("smtp down")):
+            fired = evaluate_alerts()
+
+        # A mail outage must not stop the remaining alerts being evaluated.
+        self.assertEqual(len(fired), 1)
+        self.assertFalse(fired[0].was_delivered)
+        self.assertIn("smtp down", fired[0].delivery_error)
+
+    def test_a_user_without_an_email_address_is_recorded(self):
+        self.user.email = ""
+        self.user.save()
+        self.make_alert()
+
+        fired = evaluate_alerts()
+
+        self.assertFalse(fired[0].was_delivered)
+        self.assertIn("No email", fired[0].delivery_error)
+
+
+class BudgetAlertTests(AlertTestCase):
+    def test_a_percentage_alert_fires(self):
+        budget, _ = self.make_budget_period(actual="700.00", target="800.00")
+
+        Alert.objects.create(
+            user=self.user,
+            name="Groceries at 80%",
+            kind=AlertKind.BUDGET_PERCENT,
+            budget=budget,
+            comparison=Comparison.ABOVE,
+            threshold=Decimal("80"),
+        )
+
+        fired = evaluate_alerts()
+
+        self.assertEqual(len(fired), 1)
+        # 700 of 800 is 87.5%, which renders rounded.
+        self.assertIn("88%", mail.outbox[0].body)
+
+    def test_an_amount_alert_fires(self):
+        budget, _ = self.make_budget_period(actual="750.00")
+
+        Alert.objects.create(
+            user=self.user,
+            name="Groceries past $700",
+            kind=AlertKind.BUDGET_AMOUNT,
+            budget=budget,
+            comparison=Comparison.ABOVE,
+            threshold=Decimal("700.00"),
+        )
+
+        self.assertEqual(len(evaluate_alerts()), 1)
+
+    def test_the_period_gate_suppresses_a_late_period_alert(self):
+        budget, period = self.make_budget_period(actual="700.00")
+
+        # "Tell me only if we pass 80% before we are 10% through the month."
+        Alert.objects.create(
+            user=self.user,
+            name="Groceries too fast",
+            kind=AlertKind.BUDGET_PERCENT,
+            budget=budget,
+            comparison=Comparison.ABOVE,
+            threshold=Decimal("80"),
+            only_after_period_fraction=0.0,
+        )
+
+        period.period_start = timezone.localdate() - timedelta(days=1)
+        period.period_end = timezone.localdate() + timedelta(days=200)
+        period.save()
+
+        # Barely into a long period, so the gate at 0.0 still passes.
+        self.assertEqual(len(evaluate_alerts()), 1)
+
+    def test_the_period_gate_blocks_when_not_far_enough_through(self):
+        budget, period = self.make_budget_period(actual="700.00")
+
+        Alert.objects.create(
+            user=self.user,
+            name="Groceries too fast",
+            kind=AlertKind.BUDGET_PERCENT,
+            budget=budget,
+            comparison=Comparison.ABOVE,
+            threshold=Decimal("80"),
+            only_after_period_fraction=0.9,
+        )
+
+        period.period_start = timezone.localdate()
+        period.period_end = timezone.localdate() + timedelta(days=60)
+        period.save()
+
+        self.assertEqual(evaluate_alerts(), [])
+
+    def test_a_budget_with_no_current_period_does_not_fire(self):
+        budget = Budget.objects.create(name="Unrolled", amount=Decimal("500"))
+
+        Alert.objects.create(
+            user=self.user,
+            name="Never",
+            kind=AlertKind.BUDGET_PERCENT,
+            budget=budget,
+            comparison=Comparison.ABOVE,
+            threshold=Decimal("50"),
+        )
+
+        self.assertEqual(evaluate_alerts(), [])
+
+    def test_the_message_includes_pacing(self):
+        budget, _ = self.make_budget_period(actual="700.00")
+
+        Alert.objects.create(
+            user=self.user,
+            name="Groceries",
+            kind=AlertKind.BUDGET_PERCENT,
+            budget=budget,
+            comparison=Comparison.ABOVE,
+            threshold=Decimal("50"),
+        )
+
+        evaluate_alerts()
+
+        self.assertIn("pace", mail.outbox[0].body)
+
+    def test_dry_run_records_without_sending(self):
+        budget, _ = self.make_budget_period(actual="700.00")
+        Alert.objects.create(
+            user=self.user,
+            name="Groceries",
+            kind=AlertKind.BUDGET_PERCENT,
+            budget=budget,
+            comparison=Comparison.ABOVE,
+            threshold=Decimal("50"),
+        )
+
+        call_command("send_alerts", "--dry-run", verbosity=0)
+
+        self.assertEqual(AlertEvent.objects.count(), 1)
+        self.assertEqual(len(mail.outbox), 0)
+
+
+class ReportTests(AlertTestCase):
+    def make_report(self, **kwargs):
+        kwargs.setdefault("name", "Weekly summary")
+        kwargs.setdefault("cadence", ReportCadence.WEEKLY)
+        kwargs.setdefault("sections", ["balances", "budgets", "spend"])
+        kwargs.setdefault("send_day", timezone.localdate().isoweekday())
+
+        return ScheduledReport.objects.create(user=self.user, **kwargs)
+
+    def test_a_due_report_is_sent(self):
+        self.make_budget_period()
+        report = self.make_report()
+
+        sent = report_service.send_due_reports()
+
+        self.assertEqual(len(sent), 1)
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertIn("BALANCES", mail.outbox[0].body)
+        self.assertIn("Groceries", mail.outbox[0].body)
+
+        report.refresh_from_db()
+        self.assertIsNotNone(report.last_sent_at)
+
+    def test_a_report_due_another_day_is_not_sent(self):
+        other_day = (timezone.localdate().isoweekday() % 7) + 1
+        self.make_report(send_day=other_day)
+
+        self.assertEqual(report_service.send_due_reports(), [])
+
+    def test_a_report_is_not_sent_twice_in_one_day(self):
+        self.make_report()
+
+        report_service.send_due_reports()
+        report_service.send_due_reports()
+
+        self.assertEqual(len(mail.outbox), 1)
+
+    def test_only_the_chosen_sections_appear(self):
+        self.make_budget_period()
+        self.make_report(sections=["budgets"])
+
+        report_service.send_due_reports()
+
+        body = mail.outbox[0].body
+        self.assertIn("BUDGETS", body)
+        self.assertNotIn("BALANCES", body)
+
+    def test_the_review_section_reports_the_queue(self):
+        transaction = make_transaction(self.checking, description_raw="MYSTERY")
+        transaction.needs_review = True
+        transaction.save()
+
+        self.make_report(sections=["review"])
+        report_service.send_due_reports()
+
+        self.assertIn("1 transaction waiting", mail.outbox[0].body)
+
+    def test_inactive_reports_are_skipped(self):
+        self.make_report(is_active=False)
+
+        self.assertEqual(report_service.send_due_reports(), [])
+
+    def test_a_monthly_report_is_due_on_its_day_of_month(self):
+        today = timezone.localdate()
+        report = self.make_report(
+            cadence=ReportCadence.MONTHLY, send_day=min(today.day, 28)
+        )
+
+        if today.day <= 28:
+            self.assertTrue(report_service.is_due(report, today))
+
+    def test_a_send_failure_leaves_last_sent_alone_so_it_retries(self):
+        report = self.make_report()
+
+        with patch("finance.services.reports.send_mail", side_effect=OSError("smtp down")):
+            self.assertEqual(report_service.send_due_reports(), [])
+
+        report.refresh_from_db()
+        self.assertIsNone(report.last_sent_at)
+
+
+class ChainTests(AlertTestCase):
+    def test_the_hourly_chain_runs_every_step_in_order(self):
+        with patch("finance.management.commands.finance_hourly.call_command") as call:
+            call_command("finance_hourly", verbosity=0)
+
+        self.assertEqual(
+            [c.args[0] for c in call.call_args_list],
+            ["sync_accounts", "categorize_transactions", "rollup_budgets", "send_alerts"],
+        )
+
+    def test_the_daily_chain_runs_every_step_in_order(self):
+        with patch("finance.management.commands.finance_daily.call_command") as call:
+            call_command("finance_daily", verbosity=0)
+
+        self.assertEqual(
+            [c.args[0] for c in call.call_args_list],
+            [
+                "sync_accounts",
+                "categorize_transactions",
+                "snapshot_balances",
+                "rollup_budgets",
+                "send_reports",
+            ],
+        )
+
+    def test_the_hourly_sync_is_limited_to_day_to_day_accounts(self):
+        with patch("finance.management.commands.finance_hourly.call_command") as call:
+            call_command("finance_hourly", verbosity=0)
+
+        self.assertTrue(call.call_args_list[0].kwargs["high_frequency_only"])
+
+    def test_the_daily_sync_covers_everything(self):
+        with patch("finance.management.commands.finance_daily.call_command") as call:
+            call_command("finance_daily", verbosity=0)
+
+        self.assertNotIn("high_frequency_only", call.call_args_list[0].kwargs)
+
+    def test_a_failing_step_does_not_stop_the_rest(self):
+        def fail_on_sync(name, *args, **kwargs):
+            if name == "sync_accounts":
+                raise RuntimeError("provider down")
+
+        with patch(
+            "finance.management.commands.finance_hourly.call_command",
+            side_effect=fail_on_sync,
+        ) as call:
+            with self.assertRaises(SystemExit):
+                call_command("finance_hourly", verbosity=0)
+
+        # Budgets still roll up from the data already present.
+        self.assertEqual(len(call.call_args_list), 4)
+
+    def test_a_failing_chain_exits_non_zero(self):
+        with patch(
+            "finance.management.commands.finance_daily.call_command",
+            side_effect=RuntimeError("boom"),
+        ):
+            with self.assertRaises(SystemExit) as caught:
+                call_command("finance_daily", verbosity=0)
+
+        # Non-zero so a broken scheduled run is visible in Heroku's logs.
+        self.assertEqual(caught.exception.code, 1)
+
+
+class AlertUIScopingTests(AlertTestCase):
+    """Alerts are personal — one person must never see or edit the other's."""
+
+    def setUp(self):
+        super().setUp()
+
+        from django_otp.plugins.otp_totp.models import TOTPDevice
+
+        self.device = TOTPDevice.objects.create(user=self.user, name="d", confirmed=True)
+        self.maddie = make_user("maddie")
+
+        self.mine = Alert.objects.create(
+            user=self.user,
+            name="Mine",
+            kind=AlertKind.ACCOUNT_BALANCE,
+            account=self.checking,
+            comparison=Comparison.BELOW,
+            threshold=Decimal("500"),
+        )
+        self.theirs = Alert.objects.create(
+            user=self.maddie,
+            name="Theirs",
+            kind=AlertKind.ACCOUNT_BALANCE,
+            account=self.checking,
+            comparison=Comparison.BELOW,
+            threshold=Decimal("100"),
+        )
+
+        self.client.force_login(self.user)
+        session = self.client.session
+        session["otp_device_id"] = self.device.persistent_id
+        session.save()
+
+    def test_the_list_shows_only_my_alerts(self):
+        from django.urls import reverse
+
+        response = self.client.get(reverse("finance:alerts"))
+
+        self.assertContains(response, "Mine")
+        self.assertNotContains(response, "Theirs")
+
+    def test_i_cannot_open_someone_elses_alert(self):
+        from django.urls import reverse
+
+        response = self.client.get(reverse("finance:alert_edit", args=[self.theirs.pk]))
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_a_new_alert_is_filed_under_me(self):
+        from django.urls import reverse
+
+        self.client.post(
+            reverse("finance:alert_create"),
+            {
+                "name": "New one",
+                "kind": AlertKind.ACCOUNT_BALANCE,
+                "account": self.checking.pk,
+                "comparison": Comparison.BELOW,
+                "threshold": "300",
+                "cooldown_hours": 24,
+                "is_active": "on",
+            },
+        )
+
+        self.assertEqual(Alert.objects.get(name="New one").user, self.user)
+
+    def test_each_person_is_alerted_at_their_own_threshold(self):
+        # Checking is at $250, so both thresholds are breached differently.
+        self.maddie.email = "maddie@example.com"
+        self.maddie.save()
+
+        fired = evaluate_alerts()
+
+        self.assertEqual({event.alert.name for event in fired}, {"Mine"})

--- a/finance/urls.py
+++ b/finance/urls.py
@@ -2,6 +2,7 @@ from django.urls import path
 
 from . import (
     views,
+    views_alerts,
     views_auth,
     views_budgets,
     views_dashboards,
@@ -24,6 +25,13 @@ urlpatterns = [
     path("settings/accounts/<int:pk>/", views_settings.AccountUpdateView.as_view(), name="account_edit"),
     path("settings/rules/", views_settings.RuleListView.as_view(), name="rules"),
     path("preferences/", views_settings.PreferencesView.as_view(), name="preferences"),
+    # Alerts and reports
+    path("alerts/", views_alerts.AlertListView.as_view(), name="alerts"),
+    path("alerts/new/", views_alerts.AlertCreateView.as_view(), name="alert_create"),
+    path("alerts/<int:pk>/", views_alerts.AlertUpdateView.as_view(), name="alert_edit"),
+    path("alerts/<int:pk>/delete/", views_alerts.AlertDeleteView.as_view(), name="alert_delete"),
+    path("reports/new/", views_alerts.ReportCreateView.as_view(), name="report_create"),
+    path("reports/<int:pk>/", views_alerts.ReportUpdateView.as_view(), name="report_edit"),
     # Budgets
     path("budgets/", views_budgets.BudgetListView.as_view(), name="budgets"),
     path("budgets/new/", views_budgets.BudgetCreateView.as_view(), name="budget_create"),

--- a/finance/views_alerts.py
+++ b/finance/views_alerts.py
@@ -7,7 +7,7 @@ user rather than to the household.
 
 from django import forms
 from django.contrib import messages
-from django.shortcuts import get_object_or_404, redirect
+from django.shortcuts import redirect
 from django.urls import reverse_lazy
 from django.views.generic import CreateView, DeleteView, ListView, UpdateView
 

--- a/finance/views_alerts.py
+++ b/finance/views_alerts.py
@@ -1,0 +1,205 @@
+"""Alert and report configuration.
+
+Both are personal — each person gets their own alerts at their own thresholds,
+delivered to their own address — so every queryset is scoped to the signed-in
+user rather than to the household.
+"""
+
+from django import forms
+from django.contrib import messages
+from django.shortcuts import get_object_or_404, redirect
+from django.urls import reverse_lazy
+from django.views.generic import CreateView, DeleteView, ListView, UpdateView
+
+from .access import FinanceAccessMixin
+from .models import Account, Alert, Budget, ScheduledReport
+from .services.reports import SECTION_CHOICES, send_report
+
+FIELD_CLASSES = (
+    "w-full rounded-button border border-border bg-background px-3 py-2 text-sm "
+    "text-text-primary focus:outline-none focus:ring-2 focus:ring-primary"
+)
+
+CHECKBOX_CLASSES = (
+    "h-4 w-4 rounded border-border bg-background text-primary focus:ring-primary"
+)
+
+
+class AlertForm(forms.ModelForm):
+    class Meta:
+        model = Alert
+        fields = [
+            "name", "kind", "account", "budget", "comparison", "threshold",
+            "only_after_period_fraction", "cooldown_hours", "is_active",
+        ]
+        widgets = {
+            "name": forms.TextInput(attrs={"class": FIELD_CLASSES}),
+            "kind": forms.Select(attrs={"class": FIELD_CLASSES}),
+            "account": forms.Select(attrs={"class": FIELD_CLASSES}),
+            "budget": forms.Select(attrs={"class": FIELD_CLASSES}),
+            "comparison": forms.Select(attrs={"class": FIELD_CLASSES}),
+            "threshold": forms.NumberInput(attrs={"class": FIELD_CLASSES, "step": "0.01"}),
+            "only_after_period_fraction": forms.NumberInput(
+                attrs={"class": FIELD_CLASSES, "step": "0.05", "min": 0, "max": 1}
+            ),
+            "cooldown_hours": forms.NumberInput(attrs={"class": FIELD_CLASSES, "min": 1}),
+            "is_active": forms.CheckboxInput(attrs={"class": CHECKBOX_CLASSES}),
+        }
+        help_texts = {
+            "threshold": "A dollar amount, or a percentage for budget-percent alerts.",
+            "only_after_period_fraction": (
+                "Optional, 0–1. Only fire past this point in the budget period — "
+                "0.5 means 'only in the second half of the month'."
+            ),
+        }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["account"].queryset = Account.objects.filter(is_active=True)
+        self.fields["budget"].queryset = Budget.objects.filter(is_active=True)
+        self.fields["account"].required = False
+        self.fields["budget"].required = False
+
+
+class AlertListView(FinanceAccessMixin, ListView):
+    template_name = "finance/alerts/list.html"
+    context_object_name = "alerts"
+
+    def get_queryset(self):
+        # Personal: never surface the other person's thresholds.
+        return Alert.objects.filter(user=self.request.user).select_related(
+            "account", "budget"
+        )
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["page_title"] = "Alerts & reports"
+        context["reports"] = ScheduledReport.objects.filter(user=self.request.user)
+        return context
+
+
+class AlertCreateView(FinanceAccessMixin, CreateView):
+    template_name = "finance/alerts/form.html"
+    form_class = AlertForm
+    success_url = reverse_lazy("finance:alerts")
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["page_title"] = "New alert"
+        return context
+
+    def form_valid(self, form):
+        form.instance.user = self.request.user
+        messages.success(self.request, f"Created “{form.instance.name}”.")
+        return super().form_valid(form)
+
+
+class AlertUpdateView(FinanceAccessMixin, UpdateView):
+    template_name = "finance/alerts/form.html"
+    form_class = AlertForm
+    success_url = reverse_lazy("finance:alerts")
+
+    def get_queryset(self):
+        return Alert.objects.filter(user=self.request.user)
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["page_title"] = "Edit alert"
+        return context
+
+
+class AlertDeleteView(FinanceAccessMixin, DeleteView):
+    template_name = "finance/alerts/confirm_delete.html"
+    success_url = reverse_lazy("finance:alerts")
+    context_object_name = "alert"
+
+    def get_queryset(self):
+        return Alert.objects.filter(user=self.request.user)
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["page_title"] = "Delete alert"
+        return context
+
+
+class ReportForm(forms.ModelForm):
+    sections_selected = forms.MultipleChoiceField(
+        label="Include",
+        choices=SECTION_CHOICES,
+        required=False,
+        widget=forms.CheckboxSelectMultiple(attrs={"class": CHECKBOX_CLASSES}),
+    )
+
+    class Meta:
+        model = ScheduledReport
+        fields = ["name", "cadence", "send_day", "is_active"]
+        widgets = {
+            "name": forms.TextInput(attrs={"class": FIELD_CLASSES}),
+            "cadence": forms.Select(attrs={"class": FIELD_CLASSES}),
+            "send_day": forms.NumberInput(attrs={"class": FIELD_CLASSES, "min": 1, "max": 28}),
+            "is_active": forms.CheckboxInput(attrs={"class": CHECKBOX_CLASSES}),
+        }
+        help_texts = {"send_day": "Weekly: 1 is Monday. Monthly: day of the month, 1–28."}
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.instance.pk:
+            self.fields["sections_selected"].initial = self.instance.sections
+
+    def save(self, commit=True):
+        report = super().save(commit=False)
+
+        chosen = set(self.cleaned_data["sections_selected"])
+        # Canonical order, so the email always reads the same way.
+        report.sections = [slug for slug, _ in SECTION_CHOICES if slug in chosen]
+
+        if commit:
+            report.save()
+
+        return report
+
+
+class ReportCreateView(FinanceAccessMixin, CreateView):
+    template_name = "finance/alerts/report_form.html"
+    form_class = ReportForm
+    success_url = reverse_lazy("finance:alerts")
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["page_title"] = "New report"
+        return context
+
+    def form_valid(self, form):
+        form.instance.user = self.request.user
+        messages.success(self.request, f"Created “{form.instance.name}”.")
+        return super().form_valid(form)
+
+
+class ReportUpdateView(FinanceAccessMixin, UpdateView):
+    template_name = "finance/alerts/report_form.html"
+    form_class = ReportForm
+    success_url = reverse_lazy("finance:alerts")
+
+    def get_queryset(self):
+        return ScheduledReport.objects.filter(user=self.request.user)
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["page_title"] = "Edit report"
+        return context
+
+    def post(self, request, *args, **kwargs):
+        if request.POST.get("action") == "send_test":
+            report = self.get_object()
+
+            if send_report(report):
+                messages.success(request, f"Sent a copy to {request.user.email}.")
+            else:
+                messages.error(
+                    request,
+                    "Could not send — check the address on your account and the mail settings.",
+                )
+
+            return redirect("finance:report_edit", pk=report.pk)
+
+        return super().post(request, *args, **kwargs)


### PR DESCRIPTION
Stacked on `finance/settings-preferences`. The last branch — threshold alerts, emailed summaries, and the two Heroku Scheduler chains that drive the whole app.

## Alerts

Personal, not household: each person's thresholds go to their own address, and every queryset is scoped to the signed-in user. Tests assert one person can't see or open the other's.

Two decisions shape how these behave:

**Cooldowns (24h by default).** The hourly chain re-evaluates everything, so without one a breached threshold would email *every hour* until it cleared. An alert people mute is worse than no alert.

**Stale-balance honesty.** An alert derived from a balance that hasn't refreshed in days is a guess. It still fires — silence would be worse — but the email says so. False confidence is the worse failure.

Budget alerts can gate on **how far through the period** they are, which is what makes *"80% of the groceries before the 15th"* expressible. The same spend is unremarkable on the 28th and worth knowing about on the 8th.

Card thresholds compare **amounts owed**, so "above $2,000" means what you'd mean rather than depending on the storage sign.

## Reports

Weekly or monthly, with per-report section selection — one of you can take the full picture, the other just budgets. Plain text on purpose: these arrive on phones, and a summary that reads in a notification preview beats one needing images loaded. There's a "send me one now" button so you can see it before committing to a schedule.

## Failure handling

Delivery failures are **recorded, never raised** — a mail outage must not stop the remaining alerts being evaluated. A failed report leaves `last_sent_at` untouched so it retries rather than silently skipping a week.

## The two scheduler jobs

| Frequency | Command | Does |
|---|---|---|
| Hourly | `python manage.py finance_hourly` | Sync day-to-day accounts → categorise → roll up budgets → evaluate alerts |
| Daily | `python manage.py finance_daily` | Sync *everything* → categorise → snapshot balances → roll up → send due reports |

Order matters: alerts must see freshly rolled-up budgets, which must see freshly categorised transactions.

Each step is **isolated** — a failing sync still lets budgets roll up from data already present — and the chain **exits non-zero** if any step failed, so a broken run appears in `heroku logs` instead of passing quietly. Verified both: with the sync step failing, the remaining four steps ran and the command exited 1.

The hourly job is deliberately restricted to accounts that actually move hourly; SimpleFIN allows ~24 requests a day, and the mortgage doesn't change between breakfast and lunch.

## Runbook

[`finance/RUNBOOK.md`](finance/RUNBOOK.md) — first-time setup, config vars, scheduler jobs, key rotation, and a "when something looks wrong" section covering stale balances, inverted liability signs, and missing categorisation.

Also stops test runs initialising a real Sentry client — the previous settings re-initialised *after* the import, so the first client was already live.

## Verification

320 tests. Notably:

- A breached threshold emails once, not once per hourly run; it fires again after the cooldown expires
- A card at −$2,400 triggers an "above $2,000" alert with an observed value of $2,400
- A stale balance adds the caveat to the email body
- The period gate blocks an alert early in a long period and passes it later
- An SMTP failure records the error, leaves the alert undelivered, and doesn't raise
- A report doesn't send twice in one day; a failed send leaves it due for retry
- Both chains call their steps in the right order with the right arguments, survive a failing step, and exit 1

---

**This completes the stack.** Merging order is bottom-up: #15 → #16 → #17 → #18 → #19 → #20 → #21 → #22 → #23 → #24 → #25, each into the one below, then `feature/finance-app` into `main`. `FIELD_ENCRYPTION_KEYS` must be set on Heroku before #18 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)