### PR TITLE
Fix sync requesting more than 90 days and tripping SimpleFIN's cap

### DIFF
--- a/finance/services/sync.py
+++ b/finance/services/sync.py
@@ -48,7 +48,17 @@ OVERLAP_DAYS = 7
 
 # First sync of a new connection: enough history for budgets and dashboards to
 # have something to say immediately.
-INITIAL_HISTORY_DAYS = 90
+#
+# Kept a few days short of SimpleFIN's stated 90-day cap rather than equal to
+# it. The adapter sends `since` as midnight UTC (test_the_since_date_is_sent
+# _as_an_epoch_start_date) so the actual elapsed span to "now" always has a
+# fractional day added on top of the nominal day count — and household_today()
+# can already be a day behind UTC late in the evening in America/Chicago. A
+# value of exactly 90 reliably tips over SimpleFIN's limit and gets the
+# request capped, which then reports as a sync error and — because
+# last_synced_at never advances on a failed run — repeats on every retry
+# instead of self-correcting.
+INITIAL_HISTORY_DAYS = 87
 
 # Name fragments that reliably indicate an account type. Only used to
 # pre-fill a guess on first discovery; the type is editable in settings.

--- a/finance/tests/test_sync.py
+++ b/finance/tests/test_sync.py
@@ -1,8 +1,10 @@
 """The sync service: idempotency, sign normalisation, and failure isolation."""
 
-from datetime import date
+from datetime import date, datetime
+from datetime import timezone as dt_timezone
 from decimal import Decimal
 from unittest.mock import patch
+from zoneinfo import ZoneInfo
 
 from django.test import TestCase
 from django.utils import timezone
@@ -24,6 +26,8 @@ from finance.providers.base import (
     TransactionPayload,
 )
 from finance.services.sync import (
+    INITIAL_HISTORY_DAYS,
+    default_since,
     guess_account_type,
     normalise_balance,
     sync_connection,
@@ -76,6 +80,42 @@ class SyncTestCase(TestCase):
                 adapter.fetch.return_value = result if result is not None else fetch_result()
 
             return sync_connection(self.connection)
+
+
+class InitialHistoryWindowTests(SyncTestCase):
+    """The window requested on a brand-new connection must stay under
+    SimpleFIN's 90-day cap regardless of what time of day the sync runs.
+
+    Two sources of slop stack in the same direction: the adapter sends
+    `since` as midnight UTC (so the true elapsed span to "now" always has a
+    fractional day added on top of the nominal day count), and
+    household_today() can already be a day behind UTC late in the evening in
+    America/Chicago. Both are exercised here via the worst case: just before
+    midnight Chicago time, when UTC has already rolled over to the next day.
+    """
+
+    def test_the_initial_window_never_exceeds_the_90_day_cap(self):
+        worst_case_now = datetime(
+            2026, 8, 4, 23, 59, 59, tzinfo=ZoneInfo("America/Chicago")
+        )
+
+        with patch("finance.dates.timezone.now", return_value=worst_case_now):
+            since = default_since(self.connection)
+
+        # Mirrors providers.simplefin._get_accounts' own construction of the
+        # start-date param, so this checks what SimpleFIN actually receives.
+        start_date_epoch = datetime(
+            since.year, since.month, since.day, tzinfo=dt_timezone.utc
+        ).timestamp()
+
+        elapsed_seconds = worst_case_now.timestamp() - start_date_epoch
+
+        self.assertLessEqual(elapsed_seconds, 90 * 86400)
+
+    def test_the_constant_leaves_a_real_margin_under_90(self):
+        # Guards against someone bumping this back toward 90 without
+        # re-checking the worst case above.
+        self.assertLessEqual(INITIAL_HISTORY_DAYS, 88)
 
 
 class IdempotencyTests(SyncTestCase):


### PR DESCRIPTION
## Summary

A brand-new connection's first sync asked for exactly 90 days of history, sent as midnight UTC on that day. Compared against "now" (always later in the day), the actual elapsed span was always over 90 days by a fractional day — and up to another full day on top of that in the evening in America/Chicago, where `household_today()` can already be a day behind UTC. SimpleFIN capped the request and reported it as an error: `Requested date range exceeds limit of 90 days and was capped.`

That error was self-perpetuating: a sync run with any provider error is marked failed rather than synced, so `last_synced_at` never advances, so every retry — including a manual "Sync now" — recomputed the same over-90-day window and hit the same cap again. It would never have self-corrected on its own.

Fixed by giving the initial window a real margin (87 days) instead of matching the cap exactly. Once a connection completes one clean sync, `last_synced_at` is set and every later sync uses the 7-day overlap window instead, well clear of the cap.

## Test plan

- [x] 451 tests passing (2 new: one reproduces the exact failure at the worst time-of-day and confirms the fix clears it — verified it fails against the old value of 90 first — and one guards against the margin creeping back toward 90 later)
- [x] `makemigrations --check --dry-run` clean (code-only change, no schema impact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)