### PR TITLE
Net refunds and credits against spend

### DIFF
--- a/finance/services/analytics.py
+++ b/finance/services/analytics.py
@@ -44,13 +44,25 @@ def spend_filter() -> Q:
     failures, a broken categorise run would have made the dashboards
     under-report spend while looking perfectly healthy.
 
+    A positive amount against an expense category counts too — a refund or a
+    credit posted as its own transaction should net back against the outflow
+    it corrects, not sit invisibly outside every spend total just because its
+    sign differs from the purchase. This is deliberately narrower than "any
+    positive amount, any category": an *uncategorised* positive transaction
+    is far more likely to be income the classifier hasn't reached yet than a
+    refund, so that bucket keeps the original amount__lt=0 requirement.
+    Aggregates built on this Q floor a negative net (more refunded than
+    spent) at zero rather than showing a category as having "spent" a
+    negative amount — see spend_over_time / spend_by_category.
+
     Split out from spend_transactions() so the activity list can apply this
     exact definition (via TransactionListView's `spend=1`) without also being
     forced to supply a date range — a chart click already carries its own
     start/end, and re-deriving them here would risk the two drifting apart.
     """
-    return Q(is_transfer=False, amount__lt=0) & (
-        Q(category__kind=CategoryKind.EXPENSE) | Q(category__isnull=True)
+    return Q(is_transfer=False) & (
+        Q(category__kind=CategoryKind.EXPENSE)
+        | Q(category__isnull=True, amount__lt=0)
     )
 
 
@@ -104,7 +116,11 @@ def spend_over_time(start, end, *, grain="monthly", account_ids=None):
 
     return {
         "labels": [row["bucket"].strftime(label_format) for row in rows],
-        "values": [float(-row["total"]) for row in rows],
+        # Floored at 0: a bucket where refunds outweighed purchases nets to a
+        # positive raw total (negated below), which would otherwise chart as
+        # negative spend — a bar reading "spent -$40" is a rendering bug, not
+        # a real answer to "how much did this period spend."
+        "values": [max(0.0, float(-row["total"])) for row in rows],
         # Exact bounds per bucket, so a chart click can filter the activity
         # list to precisely what that bar represents.
         "bucket_starts": [row["bucket"].isoformat() for row in rows],
@@ -135,6 +151,11 @@ def spend_by_category(start, end, *, account_ids=None, limit=10):
             or "Not yet categorised"
         )
         grouped[name] = grouped.get(name, Decimal("0")) + -row["total"]
+
+    # Floored per category, after rollup: a category refunded more than it
+    # spent in the window nets negative here, which would read as the
+    # category "making money" rather than what actually happened.
+    grouped = {name: max(Decimal("0"), total) for name, total in grouped.items()}
 
     ranked = sorted(grouped.items(), key=lambda item: item[1], reverse=True)
     top = ranked[:limit]

--- a/finance/services/qfr.py
+++ b/finance/services/qfr.py
@@ -95,7 +95,10 @@ def compute_metrics(start: date, end: date) -> dict:
         "net_worth_start": _f(net_worth_start),
         "net_worth_end": _f(net_worth_end),
         "net_worth_change": _f(_delta(net_worth_start, net_worth_end)),
-        "total_spend": _f(-spend_total) if spend_total else 0.0,
+        # Floored at 0 for the same reason spend_by_category floors each
+        # category: a quarter refunded more than it spent nets to a positive
+        # raw total, which would otherwise report as negative spend.
+        "total_spend": max(0.0, _f(-spend_total)) if spend_total else 0.0,
         "spend_by_category": dict(zip(by_category["labels"], by_category["values"])),
         "total_income_gross": round(sum(income["gross"]), 2),
         "total_income_net": round(sum(income["net"]), 2),

--- a/finance/tests/test_dashboards.py
+++ b/finance/tests/test_dashboards.py
@@ -106,6 +106,38 @@ class SpendAnalyticsTests(AnalyticsTestCase):
 
         self.assertEqual(result["values"], [100.0])
 
+    def test_a_refund_against_an_expense_category_nets_against_the_purchase(self):
+        self.spend("-100.00", self.groceries, 5)
+        self.spend("30.00", self.groceries, 12)  # a return, same category
+
+        result = analytics.spend_over_time(date(2026, 4, 1), date(2026, 4, 30))
+
+        self.assertEqual(result["values"], [70.0])
+
+    def test_a_positive_uncategorised_transaction_is_not_treated_as_a_refund(self):
+        # Uncategorised is far more likely to be income the classifier
+        # hasn't reached yet than a refund -- it must not net against spend.
+        self.spend("-100.00", self.groceries, 5)
+        make_transaction(
+            self.checking,
+            posted_on=date(2026, 4, 6),
+            amount=Decimal("3000.00"),
+            description_raw="UNCATEGORISED DEPOSIT",
+            category=None,
+        )
+
+        result = analytics.spend_over_time(date(2026, 4, 1), date(2026, 4, 30))
+
+        self.assertEqual(result["values"], [100.0])
+
+    def test_a_bucket_refunded_more_than_it_spent_floors_at_zero(self):
+        self.spend("-20.00", self.groceries, 5)
+        self.spend("50.00", self.groceries, 12)
+
+        result = analytics.spend_over_time(date(2026, 4, 1), date(2026, 4, 30))
+
+        self.assertEqual(result["values"], [0.0])
+
     def test_categories_roll_up_to_their_parent(self):
         self.spend("-100.00", self.groceries, 5)
         self.spend("-60.00", self.restaurants, 6)
@@ -118,6 +150,18 @@ class SpendAnalyticsTests(AnalyticsTestCase):
         # Groceries and restaurants both live under Food.
         self.assertEqual(pairs["Food"], 160.0)
         self.assertEqual(pairs["Transportation"], 40.0)
+
+    def test_a_category_refunded_more_than_it_spent_floors_at_zero_not_negative(self):
+        self.spend("-20.00", self.groceries, 5)
+        self.spend("50.00", self.groceries, 12)
+        self.spend("-40.00", self.fuel, 7)
+
+        result = analytics.spend_by_category(date(2026, 4, 1), date(2026, 4, 30))
+        pairs = dict(zip(result["labels"], result["values"]))
+
+        self.assertEqual(pairs["Food"], 0.0)
+        self.assertEqual(pairs["Transportation"], 40.0)
+        self.assertEqual(result["total"], 40.0)
 
     def test_categories_are_ranked_largest_first(self):
         self.spend("-40.00", self.fuel, 7)

--- a/finance/tests/test_qfr.py
+++ b/finance/tests/test_qfr.py
@@ -139,6 +139,14 @@ class SpendMetricsTests(ComputeMetricsTestCase):
 
         self.assertEqual(metrics["total_spend"], 100.0)
 
+    def test_a_refund_nets_against_spend_and_floors_at_zero(self):
+        self.spend(5, "-20.00")
+        self.spend(12, "50.00")  # refunded more than was spent this quarter
+
+        metrics = compute_metrics(self.start, self.end)
+
+        self.assertEqual(metrics["total_spend"], 0.0)
+
     def test_spend_by_category_is_populated(self):
         self.spend(5, "-100.00")
 


### PR DESCRIPTION
## Summary

`spend_filter()` required `amount__lt=0`, so a refund or credit posted as its own transaction — a positive amount against the same expense category as the original purchase — was invisible to every spend aggregate. It wasn't netted against the purchase, and it wasn't counted as income either, since the Income dashboard only ever reads from imported `Paycheck` records. Spend-by-category and total-spend numbers ran permanently high by however much got refunded.

The filter now includes positive amounts against an expense-kind category, so `Sum(amount)` nets naturally (a -$100 purchase and a +$30 return in the same category now read as $70 spent, not $100). Deliberately **not** "any positive amount, any category" — an uncategorised positive transaction is far more likely to be income the classifier hasn't reached yet than a refund, so that bucket keeps the original `amount__lt=0` requirement.

Aggregates built on this now floor a negative net (refunded more than spent) at zero, so a category or a quarter never reads as having "spent" a negative amount — `spend_over_time`, `spend_by_category`, and the QFR's `total_spend` all clamp.

**Not in scope:** budgets use a separate spend definition (`services/rollups.py::spend_for()`) with its own `amount__lt=0` filter, untouched here — budget attainment still won't net a refund against a category's target. Flagging in case that inconsistency matters; happy to bring it in line as a follow-up.

## Test plan

- [x] 459 tests passing — 5 new: a refund nets against the purchase in the same category (`spend_over_time`), an uncategorised positive transaction is still excluded (not mistaken for a refund), a bucket refunded more than it spent floors at 0 rather than going negative, the same flooring at the category level in `spend_by_category`, and the QFR's `total_spend` floors the same way
- [x] `makemigrations --check --dry-run` clean (no schema change), `manage.py check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)