### PR TITLE
Net refunds against budget actuals too

### DIFF
--- a/finance/services/rollups.py
+++ b/finance/services/rollups.py
@@ -41,7 +41,23 @@ def expand_categories(categories):
 
 
 def spend_for(budget: Budget, start, end) -> Decimal:
-    """Total outflow against a budget in a window, as a positive number."""
+    """Total outflow against a budget in a window, as a positive number.
+
+    A refund or credit posted in-window, against one of the budget's own
+    categories, reduces the total — this sums signed amounts across the
+    whole window rather than only the negative ones, so a return nets
+    against whatever else the category spent in *that* period. A refund
+    landing in a later period than the purchase it corrects isn't matched
+    back to it; it simply reduces that later period's own total, which can
+    read as one period high and the next low around the correction. Floored
+    at 0 so a category refunded more than it spent in a period shows as
+    "nothing spent," not negative spend.
+
+    Budget categories are always expense-kind by construction (see
+    BudgetForm), so there's no equivalent here of analytics.spend_filter()'s
+    care around uncategorised positive amounts being mistaken for a refund —
+    every category in category_ids was deliberately chosen as spending.
+    """
     category_ids = expand_categories(budget.categories.all())
 
     if not category_ids:
@@ -52,9 +68,6 @@ def spend_for(budget: Budget, start, end) -> Decimal:
         posted_on__gte=start,
         posted_on__lte=end,
         is_transfer=False,
-        # Only money leaving. A refund reduces the total, which is why this
-        # sums signed amounts rather than counting rows.
-        amount__lt=0,
     )
 
     account_ids = list(budget.accounts.values_list("pk", flat=True))
@@ -64,7 +77,7 @@ def spend_for(budget: Budget, start, end) -> Decimal:
 
     total = Transaction.objects.filter(filters).aggregate(total=Sum("amount"))["total"]
 
-    return -(total or Decimal("0"))
+    return max(Decimal("0"), -(total or Decimal("0")))
 
 
 def rollover_for(budget: Budget, start) -> Decimal:

--- a/finance/tests/test_budgets.py
+++ b/finance/tests/test_budgets.py
@@ -101,7 +101,39 @@ class SpendCalculationTests(RollupTestCase):
 
         # Signed sum, so the refund nets off rather than being ignored.
         period = roll_up_budget(budget, date(2026, 4, 20))
-        self.assertEqual(period.actual_amount, Decimal("100.00"))
+        self.assertEqual(period.actual_amount, Decimal("70.00"))
+
+    def test_a_refund_bigger_than_the_periods_spend_floors_at_zero(self):
+        budget = self.make_budget()
+        self.spend("-20.00", self.groceries)
+        self.spend("50.00", self.groceries, day=16)
+
+        period = roll_up_budget(budget, date(2026, 4, 20))
+
+        self.assertEqual(period.actual_amount, Decimal("0"))
+
+    def test_a_refund_in_a_later_period_does_not_retroactively_adjust_the_earlier_one(self):
+        budget = self.make_budget()
+        self.spend("-100.00", self.groceries, day=20)  # April: the purchase
+
+        april = roll_up_budget(budget, date(2026, 4, 20))
+        self.assertEqual(april.actual_amount, Decimal("100.00"))
+
+        make_transaction(
+            self.checking,
+            posted_on=date(2026, 5, 5),
+            amount=Decimal("100.00"),
+            description_raw="REFUND",
+            category=self.groceries,
+        )
+        may = roll_up_budget(budget, date(2026, 5, 20))
+
+        # April still reads as spent -- rollups are computed per period from
+        # what posted in that period's own window, not retroactively matched
+        # back to the original purchase.
+        april.refresh_from_db()
+        self.assertEqual(april.actual_amount, Decimal("100.00"))
+        self.assertEqual(may.actual_amount, Decimal("0"))
 
     def test_transfers_never_count(self):
         budget = self.make_budget()

--- a/finance/tests/test_click_throughs.py
+++ b/finance/tests/test_click_throughs.py
@@ -144,11 +144,20 @@ class TransactionListFilterTests(TestCase):
         self.assertEqual({t.pk for t in results}, {in_budget_1.pk, in_budget_2.pk})
         self.assertNotIn(out_of_budget.pk, {t.pk for t in results})
 
-    def test_budget_filter_excludes_transfers_and_inflow_like_the_rollup_does(self):
+    def test_budget_filter_excludes_transfers_like_the_rollup_does(self):
         self.spend(self.groceries, day=5)
         transfer = self.spend(self.groceries, amount="-100.00", day=6)
         transfer.is_transfer = True
         transfer.save()
+
+        results = self.get_transactions(
+            budget=self.budget.pk, start="2026-04-01", end="2026-04-30"
+        )
+
+        self.assertNotIn(transfer.pk, {t.pk for t in results})
+
+    def test_budget_filter_includes_a_refund_like_the_rollup_does(self):
+        purchase = self.spend(self.groceries, day=5)
         refund = self.spend(self.groceries, amount="30.00", day=7)
 
         results = self.get_transactions(
@@ -156,8 +165,8 @@ class TransactionListFilterTests(TestCase):
         )
         ids = {t.pk for t in results}
 
-        self.assertNotIn(transfer.pk, ids)
-        self.assertNotIn(refund.pk, ids)
+        self.assertIn(purchase.pk, ids)
+        self.assertIn(refund.pk, ids)
 
     def test_budget_filter_honours_the_budgets_own_account_restriction(self):
         scoped = Budget.objects.create(name="Card only", amount=Decimal("200"))

--- a/finance/views_transactions.py
+++ b/finance/views_transactions.py
@@ -57,7 +57,10 @@ class TransactionListView(FinanceAccessMixin, ListView):
 
         budgets = self.filtered_budgets()
         if budgets:
-            queryset = queryset.filter(self._budgets_q(budgets), is_transfer=False, amount__lt=0)
+            # No amount__lt=0 here — a refund against one of the budget's own
+            # categories is part of "what counts toward it" too, the same
+            # definition services.rollups.spend_for() sums.
+            queryset = queryset.filter(self._budgets_q(budgets), is_transfer=False)
 
         if self.request.GET.get("spend") == "1":
             # Independent of budget — a chart click and a budget click-through


### PR DESCRIPTION
## Summary

Follow-up to #34 (net refunds against the Spend/QFR dashboards) — budgets had their own, separate spend definition (`services/rollups.py::spend_for()`) that still excluded refunds via its own `amount__lt=0` filter, inconsistent with the dashboards.

Notably, `spend_for()`'s own docstring already claimed "a refund reduces the total, which is why this sums signed amounts rather than counting rows" — and a pre-existing test, `test_a_refund_reduces_the_total`, asserted the *opposite* of its own name and that comment (that the total stayed unchanged), which is how this went unnoticed until now.

Budget categories are always expense-kind by construction (`BudgetForm` only offers those), so this fix doesn't need `analytics.spend_filter()`'s extra care around an uncategorised positive amount being mistaken for a refund — every category a budget selects was deliberately chosen as spending. Floored at 0 per period, same reasoning as the dashboards.

Per the user's explicit call: a refund landing in a *later* period than the purchase it corrects isn't matched back to the original — each `BudgetPeriod` is computed independently from what posted in its own window, so the purchase's period still reads high and the refund's period reads low. Accepted tradeoff, not something this PR tries to fix.

The budget "View transactions" click-through (`views_transactions.py`) drops its own separate `amount__lt=0` too, so it keeps showing exactly what feeds the number it's a click-through from.

**Needs a production step after deploy:** existing `BudgetPeriod` rows were materialized under the old logic and won't self-correct — `heroku run python manage.py rollup_budgets --backfill 12 --app datamays` needed to bring history in line.

## Test plan

- [x] 462 tests passing — fixed the pre-existing mismatched test, added a floor-at-zero case, and a case confirming a refund in a later period does *not* retroactively adjust the earlier one; also split and updated the click-through test that previously asserted a refund was excluded
- [x] `makemigrations --check --dry-run` clean (no schema change), `manage.py check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)