### PR TITLE
Apply the debt sign-convention toggle immediately

### DIFF
--- a/finance/tests/test_settings.py
+++ b/finance/tests/test_settings.py
@@ -207,6 +207,97 @@ class AccountSettingsTests(SettingsTestCase):
         self.account.refresh_from_db()
         self.assertFalse(self.account.debt_reported_positive)
 
+    def account_edit_payload(self, account, **overrides):
+        payload = {
+            "name": account.name,
+            "account_type": account.account_type,
+            "owner": "joint",
+            "sort_order": 100,
+            "notes": "",
+            "is_active": "on",
+            "include_in_net_worth": "on",
+            "include_in_spending": "on",
+        }
+        payload.update(overrides)
+        return payload
+
+    def test_toggling_the_sign_convention_flips_the_stored_balance_immediately(self):
+        card = make_account(
+            self.institution,
+            name="Capital One",
+            connection=self.connection,
+            account_type=AccountType.CREDIT_CARD,
+            current_balance=Decimal("500.00"),
+            debt_reported_positive=True,
+        )
+
+        # debt_reported_positive omitted -- an unchecked checkbox submits
+        # nothing, which is how a real browser reports "turned it off."
+        self.client.post(
+            reverse("finance:account_edit", args=[card.pk]),
+            self.account_edit_payload(card),
+        )
+
+        card.refresh_from_db()
+        self.assertFalse(card.debt_reported_positive)
+        self.assertEqual(card.current_balance, Decimal("-500.00"))
+
+    def test_toggling_it_back_on_flips_the_balance_back(self):
+        card = make_account(
+            self.institution,
+            name="Capital One",
+            connection=self.connection,
+            account_type=AccountType.CREDIT_CARD,
+            current_balance=Decimal("-500.00"),
+            debt_reported_positive=False,
+        )
+
+        self.client.post(
+            reverse("finance:account_edit", args=[card.pk]),
+            self.account_edit_payload(card, debt_reported_positive="on"),
+        )
+
+        card.refresh_from_db()
+        self.assertTrue(card.debt_reported_positive)
+        self.assertEqual(card.current_balance, Decimal("500.00"))
+
+    def test_leaving_the_toggle_unchanged_does_not_touch_the_balance(self):
+        card = make_account(
+            self.institution,
+            name="Capital One",
+            connection=self.connection,
+            account_type=AccountType.CREDIT_CARD,
+            current_balance=Decimal("500.00"),
+            debt_reported_positive=True,
+        )
+
+        self.client.post(
+            reverse("finance:account_edit", args=[card.pk]),
+            self.account_edit_payload(
+                card, name="Capital One Venture", debt_reported_positive="on"
+            ),
+        )
+
+        card.refresh_from_db()
+        self.assertEqual(card.name, "Capital One Venture")
+        self.assertEqual(card.current_balance, Decimal("500.00"))
+
+    def test_the_toggle_on_an_asset_account_never_touches_the_balance(self):
+        # Ignored for asset accounts by design (per the field's own
+        # help_text) -- guards the flip logic against a stray submission.
+        self.account.current_balance = Decimal("4200.00")
+        self.account.debt_reported_positive = True
+        self.account.save()
+
+        self.client.post(
+            reverse("finance:account_edit", args=[self.account.pk]),
+            self.account_edit_payload(self.account),
+        )
+
+        self.account.refresh_from_db()
+        self.assertFalse(self.account.debt_reported_positive)
+        self.assertEqual(self.account.current_balance, Decimal("4200.00"))
+
 
 class RuleManagementTests(SettingsTestCase):
     def setUp(self):

--- a/finance/views_settings.py
+++ b/finance/views_settings.py
@@ -385,8 +385,30 @@ class AccountUpdateView(FinanceAccessMixin, UpdateView):
         return context
 
     def form_valid(self, form):
-        messages.success(self.request, f"Updated {form.instance.name}.")
-        return super().form_valid(form)
+        # current_balance is normalised (services.sync.normalise_balance) only
+        # at sync time, so flipping this checkbox alone leaves the stored
+        # balance untouched until the next sync happens to run — which can be
+        # up to an hour away, and silently never for a manual account. Since
+        # the sign flip is self-inverse, apply it here immediately rather
+        # than make the household total wait on a background job to notice.
+        sign_flip_needed = (
+            "debt_reported_positive" in form.changed_data
+            and form.instance.is_liability
+        )
+
+        account = form.save(commit=False)
+
+        if sign_flip_needed:
+            if account.current_balance is not None:
+                account.current_balance = -account.current_balance
+            if account.available_balance is not None:
+                account.available_balance = -account.available_balance
+
+        account.save()
+        self.object = account
+
+        messages.success(self.request, f"Updated {account.name}.")
+        return redirect(self.get_success_url())
 
 
 class RuleListView(FinanceAccessMixin, ListView):


### PR DESCRIPTION
## Summary

`debt_reported_positive` was only ever applied inside `normalise_balance()` (`services/sync.py`), which runs exclusively during a provider sync. `Account.current_balance` is a cached field that only that function writes to — toggling the checkbox alone updated the flag but left `current_balance` completely untouched, so nothing visibly changed until the next sync happened to run (up to an hour away, and never for a manual account).

Separately, worth knowing (not a bug, by design): the per-account row on the Settings page and Savings & Debt dashboard always displays `abs(current_balance)` for a liability, so that specific number can never visibly reflect the toggle either way — the real signal is the household total / net worth figure, which does use the signed value.

`AccountUpdateView` now flips `current_balance` (and `available_balance`) in place when the flag actually changes for a liability account, instead of waiting on a background job to notice. The transformation is a pure sign flip — self-inverse, and exactly what the next sync would have computed anyway — so this isn't "editing data to compensate" (which the RUNBOOK explicitly warns against elsewhere), it's applying the same normalisation immediately instead of on a delay.

Gated on `form.instance.is_liability` (`account_type`-based, not sign-based) so this never touches an asset account, where the field is already documented as ignored.

## Test plan

- [x] 466 tests passing — 4 new: toggling off flips the stored balance immediately, toggling back on flips it back, leaving the checkbox unchanged (editing something else) doesn't touch the balance, and toggling it on an asset account never touches the balance
- [x] `makemigrations --check --dry-run` clean (no schema change), `manage.py check` clean

## Note for the already-toggled Capital One account in production

This fix only applies going forward — an account already toggled under the old code has a flag that matches what's already saved, so there's no "change" for this to detect. Hitting **Sync now** on that connection once after this deploys will pick up the current flag value and self-correct immediately (a sync always re-normalises from the raw provider balance); otherwise the next scheduled sync will do it within the hour regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)