### PR TITLE
Show the actual negative sign on a debt's balance

### DIFF
--- a/finance/models/accounts.py
+++ b/finance/models/accounts.py
@@ -156,13 +156,18 @@ class Account(TimestampedModel):
 
     @property
     def display_balance(self):
-        """Balance as a person reads it: a debt of $1,200 shows as 1200.
+        """The balance as stored, signed — a debt reads as a negative number.
 
-        Storage stays signed for net worth; this is for presentation only.
+        Previously abs()'d for a liability so a debt always read as a
+        positive "amount owed," but that made debt_reported_positive
+        invisible on the one screen a person would actually check it: the
+        account itself never showed a sign either way, so there was no way
+        to see whether the setting was even doing anything. Every caller
+        pairs this with the money_sign/abs_money filters (or their own sign
+        handling, for the plain-text version in services/reports.py) to
+        render the sign explicitly rather than hiding it.
         """
-        if self.current_balance is None:
-            return None
-        return abs(self.current_balance) if self.is_liability else self.current_balance
+        return self.current_balance
 
 
 class BalanceSource(models.TextChoices):

--- a/finance/services/reports.py
+++ b/finance/services/reports.py
@@ -87,7 +87,8 @@ def build_sections(report, start, end):
     if "balances" in chosen:
         accounts = list(_accounts_for(report))
         lines = [
-            f"  {account.name}: ${account.display_balance:,.2f}"
+            f"  {account.name}: "
+            f"{'-' if account.display_balance < 0 else ''}${abs(account.display_balance):,.2f}"
             for account in accounts
             if account.display_balance is not None
         ]

--- a/finance/templates/finance/dashboards/savings.html
+++ b/finance/templates/finance/dashboards/savings.html
@@ -58,7 +58,7 @@
             </p>
           </div>
           <p class="shrink-0 font-mono text-sm {% if account.is_liability %}text-warning{% endif %}">
-            ${{ account.display_balance|money }}
+            {{ account.display_balance|money_sign }}${{ account.display_balance|abs_money }}
           </p>
         </li>
       {% endfor %}

--- a/finance/templates/finance/settings/connection_detail.html
+++ b/finance/templates/finance/settings/connection_detail.html
@@ -52,7 +52,7 @@
           <a href="{% url 'finance:account_edit' account.pk %}" class="truncate text-sm font-medium hover:underline">{{ account.name }}</a>
           <p class="text-xs text-text-muted">{{ account.institution.name }} · {{ account.get_account_type_display }}</p>
         </div>
-        <p class="shrink-0 font-mono text-sm">${{ account.display_balance|money }}</p>
+        <p class="shrink-0 font-mono text-sm">{{ account.display_balance|money_sign }}${{ account.display_balance|abs_money }}</p>
       </li>
     {% empty %}
       <li class="p-4 text-sm text-text-muted">No accounts discovered yet.</li>

--- a/finance/templates/finance/settings/index.html
+++ b/finance/templates/finance/settings/index.html
@@ -83,7 +83,7 @@
               {% if not account.is_active %}· inactive{% endif %}
             </p>
           </div>
-          <p class="shrink-0 font-mono text-sm">${{ account.display_balance|money }}</p>
+          <p class="shrink-0 font-mono text-sm">{{ account.display_balance|money_sign }}${{ account.display_balance|abs_money }}</p>
         </a>
       </li>
     {% empty %}

--- a/finance/templates/finance/widgets/balances.html
+++ b/finance/templates/finance/widgets/balances.html
@@ -25,7 +25,7 @@
           {% if account.display_balance is None %}
             <span class="text-text-muted">—</span>
           {% else %}
-            ${{ account.display_balance|money }}
+            {{ account.display_balance|money_sign }}${{ account.display_balance|abs_money }}
           {% endif %}
         </p>
       </li>

--- a/finance/templatetags/finance_extras.py
+++ b/finance/templatetags/finance_extras.py
@@ -36,6 +36,22 @@ def abs_money(value, places=2):
 
 
 @register.filter
+def money_sign(value):
+    """'-' for a negative amount, '' otherwise — None-safe.
+
+    Pairs with abs_money so a template can prefix the sign without risking
+    a None comparison in {% if %}: {{ x|money_sign }}${{ x|abs_money }}.
+    """
+    if value is None or value == "":
+        return ""
+
+    try:
+        return "-" if Decimal(str(value)) < 0 else ""
+    except (InvalidOperation, TypeError, ValueError):
+        return ""
+
+
+@register.filter
 def get_item(mapping, key):
     """Look up a dict by a key held in a variable.
 

--- a/finance/tests/test_home.py
+++ b/finance/tests/test_home.py
@@ -77,7 +77,9 @@ class BalanceWidgetTests(HomepageTestCase):
         self.assertEqual(len(data["accounts"]), 2)
         self.assertEqual(data["total"], Decimal("2850.00"))
 
-    def test_a_debt_is_shown_as_a_positive_figure(self):
+    def test_a_debt_carries_its_negative_sign_into_the_widget_data(self):
+        # The template is what turns this into "-$1,350.00"; this just
+        # confirms the widget hands it the real signed value to render.
         preference = UserPreference.for_user(self.user)
         preference.homepage_widgets = ["balances"]
         preference.save()
@@ -86,7 +88,7 @@ class BalanceWidgetTests(HomepageTestCase):
             a for a in self.widget("balances")["data"]["accounts"] if a.name == "Card"
         )
 
-        self.assertEqual(card.display_balance, Decimal("1350.00"))
+        self.assertEqual(card.display_balance, Decimal("-1350.00"))
 
     def test_a_stale_balance_is_flagged(self):
         # A quietly failing sync is the worst failure: the numbers look fine,

--- a/finance/tests/test_models.py
+++ b/finance/tests/test_models.py
@@ -60,7 +60,11 @@ class SignConventionTests(TestCase):
 
         self.assertEqual(net_worth, Decimal("-286150.00"))
 
-    def test_display_balance_reads_a_debt_as_positive(self):
+    def test_display_balance_is_signed_like_current_balance(self):
+        # Previously abs()'d for a liability, which made debt_reported_positive
+        # invisible on the one screen a person would check it — the account
+        # row never showed a sign either way. Templates render the sign
+        # explicitly (money_sign + abs_money) instead of hiding it here.
         card = make_account(
             account_type=AccountType.CREDIT_CARD, current_balance=Decimal("-1350.00")
         )
@@ -68,7 +72,7 @@ class SignConventionTests(TestCase):
             name="Checking", current_balance=Decimal("4200.00")
         )
 
-        self.assertEqual(card.display_balance, Decimal("1350.00"))
+        self.assertEqual(card.display_balance, Decimal("-1350.00"))
         self.assertEqual(checking.display_balance, Decimal("4200.00"))
 
     def test_high_frequency_classification_drives_sync_cadence(self):

--- a/finance/tests/test_settings.py
+++ b/finance/tests/test_settings.py
@@ -282,6 +282,22 @@ class AccountSettingsTests(SettingsTestCase):
         self.assertEqual(card.name, "Capital One Venture")
         self.assertEqual(card.current_balance, Decimal("500.00"))
 
+    def test_the_settings_page_actually_renders_the_minus_sign_for_a_debt(self):
+        card = make_account(
+            self.institution,
+            name="Capital One",
+            connection=self.connection,
+            account_type=AccountType.CREDIT_CARD,
+            current_balance=Decimal("-500.00"),
+        )
+
+        response = self.client.get(reverse("finance:settings"))
+
+        self.assertContains(response, "-$500.00")
+        # Not the old behaviour: the raw amount must not also appear
+        # unsigned, which would mean the minus sign silently got dropped.
+        self.assertNotContains(response, ">$500.00<")
+
     def test_the_toggle_on_an_asset_account_never_touches_the_balance(self):
         # Ignored for asset accounts by design (per the field's own
         # help_text) -- guards the flip logic against a stray submission.

--- a/finance/tests/test_sync.py
+++ b/finance/tests/test_sync.py
@@ -225,8 +225,9 @@ class BalanceNormalisationTests(SyncTestCase):
         card = Account.objects.get()
         self.assertEqual(card.account_type, AccountType.CREDIT_CARD)
         self.assertEqual(card.current_balance, Decimal("-1350.00"))
-        # And still reads as a positive debt in the UI.
-        self.assertEqual(card.display_balance, Decimal("1350.00"))
+        # display_balance is signed the same as current_balance -- the sign
+        # is rendered explicitly in templates, not hidden at this layer.
+        self.assertEqual(card.display_balance, Decimal("-1350.00"))
 
     def test_an_overpaid_card_stays_a_positive_balance(self):
         # Negation rather than -abs() is what makes this come out right.


### PR DESCRIPTION
## Summary

Per user request — the debt sign-convention toggle's effect was invisible on every screen that shows a per-account balance, because `Account.display_balance` took `abs()` for any liability. A debt always read as a plain positive "amount owed," so there was no way to see `debt_reported_positive` doing anything without checking the household total specifically.

`display_balance` now just returns `current_balance`, signed. Every call site (Settings accounts list, connection detail page, Savings & Debt dashboard, homepage balances widget, and the plain-text scheduled report) renders the sign explicitly instead of hiding it.

Two things worth calling out:
- Added a `money_sign` filter rather than the naive `{% if x < 0 %}-{% endif %}` pattern used elsewhere in the app, because `display_balance` can be `None` (an account with no balance yet) and that comparison would crash on `None < 0`.
- `services/reports.py`'s plain-text version needed its own fix in Python — the naive `f"${x:,.2f}"` form puts the `$` before the minus sign (`$-1,930.72`), the same money-sign bug fixed elsewhere in the app this round.

The orange/warning coloring for liability accounts is unchanged — confirmed wanted as-is (marks "this is debt" regardless of amount, not tied to sign).

## Test plan

- [x] 467 tests passing — updated 3 pre-existing tests that asserted the old abs-value behavior, and added a real HTML-rendering test confirming `-$500.00` actually appears in the Settings page response (not just that the underlying Python value is signed)
- [x] `makemigrations --check --dry-run` clean (no schema change), `manage.py check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)