### PR TITLE
Make net income the primary Income figure, payslip detail optional

### DIFF
--- a/finance/services/analytics.py
+++ b/finance/services/analytics.py
@@ -187,8 +187,48 @@ def budget_attainment_over_time(budget, periods=12):
     }
 
 
+def income_filter() -> Q:
+    """What counts as income, as a reusable Q — the mirror image of
+    spend_filter(). Requires an explicit Income-kind category rather than
+    "any positive amount," the same conservative choice spend_filter() makes
+    in the other direction: a deposit that hasn't been categorised yet is
+    just as likely to be an uncategorised refund as it is income, so it's
+    left out until the classifier (or a person) says which."""
+    return Q(is_transfer=False, amount__gt=0, category__kind=CategoryKind.INCOME)
+
+
+def net_income_over_time(start, end, *, grain="monthly"):
+    """Net income per period, straight from deposits — no payslip required.
+
+    The primary read of "how much came in": every income-categorised deposit
+    counts, whether or not a payslip was ever imported for it. This is what
+    makes the Income dashboard work for a household member whose pay never
+    gets a detailed payslip import — see income_over_time() for the
+    optional, payslip-only gross/tax/retained breakdown layered on top.
+    """
+    trunc, label_format = GRAINS.get(grain, GRAINS["monthly"])
+
+    rows = list(
+        Transaction.objects.filter(
+            income_filter(), posted_on__gte=start, posted_on__lte=end
+        )
+        .annotate(bucket=trunc("posted_on"))
+        .values("bucket")
+        .annotate(total=Sum("amount"))
+        .order_by("bucket")
+    )
+
+    return {
+        "labels": [row["bucket"].strftime(label_format) for row in rows],
+        "values": [float(row["total"]) for row in rows],
+        "has_data": bool(rows),
+    }
+
+
 def income_over_time(start, end, *, grain="monthly"):
-    """Gross and net pay per period, plus what the gap is made of.
+    """Gross pay and where it goes, for whatever pay periods have an
+    imported payslip — optional supplementary detail, not the primary income
+    figure. See net_income_over_time() for that.
 
     Aggregators only ever see the deposit, so this reads from imported
     paychecks. Retirement and HSA are separated out because that money is
@@ -235,8 +275,10 @@ def income_over_time(start, end, *, grain="monthly"):
 def deposits_without_paychecks(start, end):
     """Income transactions with no matching paycheck record.
 
-    Surfaced so the income dashboard can say "this is incomplete" rather than
-    quietly under-reporting when a payslip has not been imported.
+    Net income never depends on this — net_income_over_time() counts every
+    one of these deposits regardless. This is purely a pointer toward the
+    optional payslip-detail section: "import a payslip for these if you want
+    gross pay and the tax/retirement breakdown for them too."
     """
     return (
         Transaction.objects.filter(

--- a/finance/services/qfr.py
+++ b/finance/services/qfr.py
@@ -78,7 +78,12 @@ def compute_metrics(start: date, end: date) -> dict:
         analytics.spend_filter(), posted_on__gte=start, posted_on__lte=end
     ).aggregate(total=Sum("amount"))["total"]
 
-    income = analytics.income_over_time(start, end, grain="monthly")
+    net_income = analytics.net_income_over_time(start, end, grain="monthly")
+    # Gross is optional supplementary detail (see analytics.income_over_time)
+    # and only ever reflects pay periods with an imported payslip — it can
+    # legitimately read lower than total_income_net for a household member
+    # whose pay is tracked from deposits alone.
+    payslip_detail = analytics.income_over_time(start, end, grain="monthly")
     by_category = analytics.spend_by_category(start, end, limit=BATCH_SIZE_CATEGORIES)
 
     savings_start = _type_balance_as_of(SAVINGS_TYPES, day_before)
@@ -100,8 +105,8 @@ def compute_metrics(start: date, end: date) -> dict:
         # raw total, which would otherwise report as negative spend.
         "total_spend": max(0.0, _f(-spend_total)) if spend_total else 0.0,
         "spend_by_category": dict(zip(by_category["labels"], by_category["values"])),
-        "total_income_gross": round(sum(income["gross"]), 2),
-        "total_income_net": round(sum(income["net"]), 2),
+        "total_income_gross": round(sum(payslip_detail["gross"]), 2),
+        "total_income_net": round(sum(net_income["values"]), 2),
         # Stored as amounts owed (positive), so "debt_change" being negative
         # always reads as "debt went down" — the way a person expects it to.
         "savings_balance_start": _f(savings_start),

--- a/finance/templates/finance/dashboards/income.html
+++ b/finance/templates/finance/dashboards/income.html
@@ -6,43 +6,63 @@
 
 {% include "finance/dashboards/_filters.html" %}
 
-{% if unmatched_count %}
-  <div class="mt-6 rounded-card border border-warning/40 bg-warning/5 p-4">
-    <p class="text-sm text-warning">
-      {{ unmatched_count }} income deposit{{ unmatched_count|pluralize }} with no payslip imported.
-    </p>
-    <p class="mt-1 text-xs text-text-muted">
-      Gross pay, tax, and retirement contributions can only be shown for pay periods
-      with an imported payslip — banks only ever report the deposit.
-      <a href="{% url 'finance:import_upload' %}" class="text-primary hover:underline">Import payslips</a>.
-    </p>
-  </div>
-{% endif %}
-
 {% if not has_data %}
   <div class="mt-8 rounded-card border border-dashed border-border bg-surface/50 p-8 text-center">
-    <p class="text-text-secondary">No payslips imported for this window.</p>
-    <a href="{% url 'finance:import_upload' %}" class="mt-2 inline-block text-primary hover:underline">Import some →</a>
+    <p class="text-text-secondary">No income for this window yet.</p>
+    <p class="mt-1 text-xs text-text-muted">
+      A deposit needs to be categorised as Income before it counts here — check
+      <a href="{% url 'finance:transactions' %}?review=1" class="text-primary hover:underline">Activity → needs review</a>
+      if a paycheck deposit hasn't landed in a category yet.
+    </p>
   </div>
 {% else %}
   <section class="mt-8 rounded-card border border-border bg-surface p-5">
-    <h2 class="text-sm font-semibold uppercase tracking-wide text-text-muted">Gross vs net</h2>
-    <div class="mt-4 h-64">
-      <canvas data-chart="lines" data-source="income-series"></canvas>
-    </div>
-    {{ income_series_json|json_script:"income-series" }}
-  </section>
-
-  <section class="mt-4 rounded-card border border-border bg-surface p-5">
-    <h2 class="text-sm font-semibold uppercase tracking-wide text-text-muted">Where gross pay goes</h2>
+    <h2 class="text-sm font-semibold uppercase tracking-wide text-text-muted">Net income</h2>
     <p class="mt-1 text-xs text-text-muted">
-      Retirement and HSA are shown apart from tax — that money is still yours.
+      Every deposit categorised as income, whether or not a payslip was imported for it.
     </p>
     <div class="mt-4 h-64">
-      <canvas data-chart="lines" data-source="income-breakdown"></canvas>
+      <canvas data-chart="bar" data-source="net-income" data-label="Net income"></canvas>
     </div>
-    {{ income_breakdown_json|json_script:"income-breakdown" }}
+    {{ net_income_json|json_script:"net-income" }}
   </section>
+
+  {% if unmatched_count %}
+    <div class="mt-4 rounded-card border border-border bg-surface/60 p-4">
+      <p class="text-sm text-text-secondary">
+        {{ unmatched_count }} deposit{{ unmatched_count|pluralize }} above with no payslip imported.
+      </p>
+      <p class="mt-1 text-xs text-text-muted">
+        Net income already counts these — importing a payslip only adds gross
+        pay and a tax/retirement breakdown for them, below.
+        <a href="{% url 'finance:import_upload' %}" class="text-primary hover:underline">Import a payslip</a>.
+      </p>
+    </div>
+  {% endif %}
+
+  {% if has_payslip_detail %}
+    <section class="mt-4 rounded-card border border-border bg-surface p-5">
+      <h2 class="text-sm font-semibold uppercase tracking-wide text-text-muted">Gross vs net</h2>
+      <p class="mt-1 text-xs text-text-muted">
+        Optional detail, only for pay periods with an imported payslip.
+      </p>
+      <div class="mt-4 h-64">
+        <canvas data-chart="lines" data-source="payslip-gross"></canvas>
+      </div>
+      {{ payslip_gross_json|json_script:"payslip-gross" }}
+    </section>
+
+    <section class="mt-4 rounded-card border border-border bg-surface p-5">
+      <h2 class="text-sm font-semibold uppercase tracking-wide text-text-muted">Where gross pay goes</h2>
+      <p class="mt-1 text-xs text-text-muted">
+        Retirement and HSA are shown apart from tax — that money is still yours.
+      </p>
+      <div class="mt-4 h-64">
+        <canvas data-chart="lines" data-source="payslip-breakdown"></canvas>
+      </div>
+      {{ payslip_breakdown_json|json_script:"payslip-breakdown" }}
+    </section>
+  {% endif %}
 {% endif %}
 {% endblock %}
 

--- a/finance/tests/test_dashboards.py
+++ b/finance/tests/test_dashboards.py
@@ -281,6 +281,82 @@ class IncomeAnalyticsTests(AnalyticsTestCase):
         self.assertEqual(unmatched.count(), 0)
 
 
+class NetIncomeAnalyticsTests(AnalyticsTestCase):
+    """The primary income figure — every income-categorised deposit, no
+    payslip required. This is what makes the Income dashboard work for a
+    household member whose pay never gets a detailed payslip import."""
+
+    def deposit(self, amount, day, category=None, month=4, **kwargs):
+        return make_transaction(
+            self.checking,
+            posted_on=date(2026, month, day),
+            amount=Decimal(amount),
+            description_raw=f"DEPOSIT {month}-{day}",
+            category=category if category is not None else self.salary,
+            **kwargs,
+        )
+
+    def test_a_deposit_with_no_payslip_still_counts(self):
+        self.deposit("3400.00", 15)
+
+        result = analytics.net_income_over_time(date(2026, 4, 1), date(2026, 4, 30))
+
+        self.assertEqual(result["values"], [3400.0])
+        self.assertTrue(result["has_data"])
+
+    def test_a_paycheck_linked_deposit_also_counts(self):
+        # net_income_over_time reads transactions directly -- a linked
+        # Paycheck record neither adds to nor is required for this total.
+        deposit = self.deposit("3400.00", 15)
+        paycheck = Paycheck.objects.create(
+            user=self.user, employer="Acme", pay_date=date(2026, 4, 15),
+            gross=Decimal("5000.00"), net=Decimal("3400.00"),
+            deposit_transaction=deposit,
+        )
+
+        result = analytics.net_income_over_time(date(2026, 4, 1), date(2026, 4, 30))
+
+        self.assertEqual(result["values"], [3400.0])
+
+    def test_transfers_are_excluded(self):
+        transfer = self.deposit("500.00", 6)
+        transfer.is_transfer = True
+        transfer.save()
+
+        result = analytics.net_income_over_time(date(2026, 4, 1), date(2026, 4, 30))
+
+        self.assertEqual(result["values"], [])
+
+    def test_spend_is_excluded(self):
+        self.deposit("-100.00", 5, category=self.groceries)
+
+        result = analytics.net_income_over_time(date(2026, 4, 1), date(2026, 4, 30))
+
+        self.assertEqual(result["values"], [])
+
+    def test_an_uncategorised_deposit_is_not_assumed_to_be_income(self):
+        # Symmetric with spend_filter()'s caution in the other direction: an
+        # uncategorised positive amount could just as easily be an
+        # uncategorised refund.
+        make_transaction(
+            self.checking,
+            posted_on=date(2026, 4, 15),
+            amount=Decimal("3400.00"),
+            description_raw="UNCATEGORISED DEPOSIT",
+            category=None,
+        )
+
+        result = analytics.net_income_over_time(date(2026, 4, 1), date(2026, 4, 30))
+
+        self.assertEqual(result["values"], [])
+
+    def test_no_income_reports_no_data_rather_than_a_zero(self):
+        result = analytics.net_income_over_time(date(2026, 4, 1), date(2026, 4, 30))
+
+        self.assertFalse(result["has_data"])
+        self.assertEqual(result["values"], [])
+
+
 class BalanceHistoryTests(AnalyticsTestCase):
     def snapshot(self, account, day, amount):
         return AccountBalanceSnapshot.objects.create(
@@ -414,7 +490,10 @@ class DashboardRenderTests(AnalyticsTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "No spending recorded")
 
-    def test_income_dashboard_warns_when_payslips_are_missing(self):
+    def test_income_dashboard_shows_net_income_with_a_payslip_note(self):
+        # No Paycheck record at all -- net income still renders from the
+        # deposit alone, with a low-key pointer toward payslip import rather
+        # than the old empty state gated on payslip data existing.
         make_transaction(
             self.checking,
             posted_on=household_today(),
@@ -426,7 +505,9 @@ class DashboardRenderTests(AnalyticsTestCase):
         response = self.client.get(reverse("finance:income"))
 
         self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "net-income")
         self.assertContains(response, "no payslip imported")
+        self.assertNotContains(response, "No income for this window yet")
 
     def test_savings_dashboard_renders(self):
         AccountBalanceSnapshot.objects.create(

--- a/finance/tests/test_qfr.py
+++ b/finance/tests/test_qfr.py
@@ -20,6 +20,7 @@ from finance.models import (
     Budget,
     BudgetPeriod,
     Category,
+    Paycheck,
     QuarterlyReport,
     Transaction,
 )
@@ -250,6 +251,40 @@ class BudgetMetricsTests(ComputeMetricsTestCase):
 
         self.assertEqual(row["actual"], 840.0)
         self.assertEqual(row["target"], 900.0)
+
+
+class IncomeMetricsTests(ComputeMetricsTestCase):
+    """total_income_net is the primary figure and reads straight from
+    deposits — a household member with no imported payslip still shows up
+    correctly. total_income_gross is optional, payslip-only detail."""
+
+    def deposit(self, day, amount="3400.00"):
+        salary = Category.objects.get(slug="income-salary")
+        return make_transaction(
+            self.checking, posted_on=date(2026, 4, day), amount=Decimal(amount),
+            category=salary, description_raw=f"PAYROLL {day}",
+        )
+
+    def test_net_income_counts_a_deposit_with_no_payslip(self):
+        self.deposit(15)
+
+        metrics = compute_metrics(self.start, self.end)
+
+        self.assertEqual(metrics["total_income_net"], 3400.0)
+        self.assertEqual(metrics["total_income_gross"], 0.0)
+
+    def test_gross_only_reflects_pay_periods_with_an_imported_payslip(self):
+        deposit = self.deposit(15)
+        Paycheck.objects.create(
+            user=make_user("david"), employer="Acme", pay_date=date(2026, 4, 15),
+            gross=Decimal("5000.00"), net=Decimal("3400.00"),
+            deposit_transaction=deposit,
+        )
+
+        metrics = compute_metrics(self.start, self.end)
+
+        self.assertEqual(metrics["total_income_net"], 3400.0)
+        self.assertEqual(metrics["total_income_gross"], 5000.0)
 
 
 class HistoricalComparisonTests(ComputeMetricsTestCase):

--- a/finance/views_dashboards.py
+++ b/finance/views_dashboards.py
@@ -166,33 +166,45 @@ class IncomeView(DashboardView):
         context = super().get_context_data(**kwargs)
         start, end = context["start"], context["end"]
 
-        income = analytics.income_over_time(start, end)
+        # The primary figure: every income-categorised deposit, whether or
+        # not a payslip was ever imported for it. Works for a household
+        # member whose pay never gets a detailed payslip.
+        net_income = analytics.net_income_over_time(start, end)
+
+        # Optional supplementary detail, layered on top for whichever pay
+        # periods do have an imported payslip.
+        payslip_detail = analytics.income_over_time(start, end)
         unmatched = analytics.deposits_without_paychecks(start, end)
 
         context.update(
             {
-                "income_series_json": {
-                    "labels": income["labels"],
-                    "series": [
-                        {"label": "Gross", "values": income["gross"]},
-                        {"label": "Net", "values": income["net"]},
-                    ],
+                "net_income_json": {
+                    "labels": net_income["labels"],
+                    "values": net_income["values"],
                 },
+                "has_data": net_income["has_data"],
+                "has_payslip_detail": payslip_detail["has_data"],
                 # Retirement and HSA are their own line rather than being
                 # lumped in with tax: that money is still the household's, and
                 # showing it as lost would understate what they actually earn.
-                "income_breakdown_json": {
-                    "labels": income["labels"],
+                "payslip_breakdown_json": {
+                    "labels": payslip_detail["labels"],
                     "series": [
-                        {"label": "Take-home", "values": income["net"]},
-                        {"label": "Tax", "values": income["tax"]},
-                        {"label": "Retirement & HSA", "values": income["retained"]},
-                        {"label": "Other deductions", "values": income["other"]},
+                        {"label": "Take-home", "values": payslip_detail["net"]},
+                        {"label": "Tax", "values": payslip_detail["tax"]},
+                        {"label": "Retirement & HSA", "values": payslip_detail["retained"]},
+                        {"label": "Other deductions", "values": payslip_detail["other"]},
                     ],
                 },
-                "has_data": income["has_data"],
-                # Surfaced rather than silently under-reporting: gross and tax
-                # only exist where a payslip has been imported.
+                "payslip_gross_json": {
+                    "labels": payslip_detail["labels"],
+                    "series": [
+                        {"label": "Gross", "values": payslip_detail["gross"]},
+                        {"label": "Net", "values": payslip_detail["net"]},
+                    ],
+                },
+                # A pointer toward optional payslip import, not a warning that
+                # anything is broken — net income above already counts these.
                 "unmatched_deposits": unmatched[:10],
                 "unmatched_count": unmatched.count(),
             }


### PR DESCRIPTION
## Summary

Answers a real setup question: without any imported payslips for a household member (direct deposit only, no detailed pay stub), their income showed up **nowhere** — not the Income dashboard, not the QFR's income section — because `income_over_time()` read exclusively from imported `Paycheck` records. `deposits_without_paychecks()` already detected income-categorised deposits with no matching payslip, but only ever surfaced it as a warning; it never drove any actual numbers.

Per explicit direction: gross/tax/deduction detail matters less than an accurate, always-available net income figure, so the page is rebuilt around that.

- **`analytics.income_filter()` / `net_income_over_time()`** — the new primary source, mirroring `spend_filter()`'s design: every income-categorised deposit counts, transfers and *uncategorised* amounts excluded (an uncategorised deposit is just as likely to be an uncategorised refund as it is income — the same caution `spend_filter()` applies in the other direction).
- **`income_over_time()`** (unchanged in code, redocumented) is now optional supplementary detail — gross pay and the tax/retirement breakdown — shown only for pay periods with an imported payslip, no longer gating whether the page shows anything at all.
- **`income.html`** leads with the net income chart; payslip detail is a clearly-labelled secondary section below it, shown only when it exists. The old hard "No payslips imported" empty state is gone — the new empty state only appears when there's genuinely no income-categorised activity at all.
- **QFR**: `total_income_net` now sums `net_income_over_time` (transaction-based); `total_income_gross` stays payslip-only, and can legitimately read lower than net for a quarter with unimported pay — that's expected, not a bug.

## Test plan

- [x] 475 tests passing — new `NetIncomeAnalyticsTests` (transfers/spend/uncategorised excluded, works with zero Paycheck records, a linked Paycheck neither adds to nor is required for the total), new `IncomeMetricsTests` on the QFR side, and the render-level test for the Income page updated to confirm it now shows net income data instead of the old payslip-gated empty state
- [x] `makemigrations --check --dry-run` clean (no schema change), `manage.py check` clean
- [x] Verified in a local browser preview with a payslip-free deposit alongside months of real payslip data — net income chart renders for every month, the payslip-detail sections still render for the months that have that data, and the unmatched-deposit note reads as an FYI rather than a warning blocking anything

🤖 Generated with [Claude Code](https://claude.com/claude-code)