### PR TITLE
Add manual balance entry as an alternative to CSV imports

### DIFF
--- a/finance/templates/finance/settings/account_form.html
+++ b/finance/templates/finance/settings/account_form.html
@@ -33,4 +33,36 @@
        class="rounded-button border border-border px-6 py-3 text-center font-medium text-text-secondary transition hover:bg-muted">Cancel</a>
   </div>
 </form>
+
+{% if balance_form %}
+  <section class="mt-10 max-w-lg rounded-card border border-border bg-surface p-5">
+    <h2 class="text-sm font-semibold uppercase tracking-wide text-text-muted">Update balance</h2>
+    <p class="mt-1.5 text-xs text-text-muted">
+      A quick one-off reading, without a full CSV import — type in today's
+      statement or account-page balance directly.
+      {% if not account.is_manual %}
+        This account syncs automatically, so a manual reading here only
+        lasts until the next sync overwrites it.
+      {% endif %}
+    </p>
+
+    <form method="post" class="mt-4 space-y-4">
+      {% csrf_token %}
+      <input type="hidden" name="action" value="update_balance" />
+
+      {% for field in balance_form %}
+        <div>
+          <label for="{{ field.id_for_label }}" class="mb-1.5 block text-sm font-medium">{{ field.label }}</label>
+          {{ field }}
+          {% if field.help_text %}<p class="mt-1.5 text-xs text-text-muted">{{ field.help_text }}</p>{% endif %}
+          {% if field.errors %}<p class="mt-1.5 text-sm text-error">{{ field.errors.0 }}</p>{% endif %}
+        </div>
+      {% endfor %}
+
+      <button type="submit" class="rounded-button border border-border px-6 py-3 font-medium transition hover:bg-muted">
+        Update balance
+      </button>
+    </form>
+  </section>
+{% endif %}
 {% endblock %}

--- a/finance/tests/test_settings.py
+++ b/finance/tests/test_settings.py
@@ -5,6 +5,7 @@ matter most here check that the boundary holds and that the stored credential
 never reaches a page.
 """
 
+from datetime import date
 from decimal import Decimal
 from unittest.mock import patch
 
@@ -15,8 +16,10 @@ from django_otp.plugins.otp_totp.models import TOTPDevice
 
 from finance.models import (
     Account,
+    AccountBalanceSnapshot,
     AccountConnection,
     AccountType,
+    BalanceSource,
     Budget,
     Category,
     CategoryRule,
@@ -333,6 +336,83 @@ class AccountSettingsTests(SettingsTestCase):
         self.account.refresh_from_db()
         self.assertFalse(self.account.debt_reported_positive)
         self.assertEqual(self.account.current_balance, Decimal("4200.00"))
+
+
+class ManualBalanceUpdateTests(SettingsTestCase):
+    """The lightweight alternative to a CSV balances import for one account."""
+
+    def update_balance(self, account, **overrides):
+        payload = {
+            "action": "update_balance",
+            "as_of": "2026-08-01",
+            "current_balance": "5000.00",
+            "available_balance": "",
+        }
+        payload.update(overrides)
+        return self.client.post(reverse("finance:account_edit", args=[account.pk]), payload)
+
+    def test_it_updates_the_account_fields(self):
+        self.update_balance(self.account, current_balance="5123.45")
+
+        self.account.refresh_from_db()
+        self.assertEqual(self.account.current_balance, Decimal("5123.45"))
+        self.assertIsNotNone(self.account.balance_as_of)
+
+    def test_it_records_a_snapshot_sourced_as_manual(self):
+        self.update_balance(self.account, current_balance="5123.45")
+
+        snapshot = AccountBalanceSnapshot.objects.get(
+            account=self.account, as_of=date(2026, 8, 1)
+        )
+        self.assertEqual(snapshot.current, Decimal("5123.45"))
+        self.assertEqual(snapshot.source, BalanceSource.MANUAL)
+
+    def test_it_works_on_a_connected_account_too(self):
+        # The account this test case sets up already has a live connection —
+        # per the explicit ask, manual entry is available for any account,
+        # not only ones with no connection.
+        self.assertIsNotNone(self.account.connection_id)
+
+        response = self.update_balance(self.account, current_balance="6000.00")
+
+        self.assertRedirects(response, reverse("finance:settings"))
+        self.account.refresh_from_db()
+        self.assertEqual(self.account.current_balance, Decimal("6000.00"))
+
+    def test_available_balance_is_optional(self):
+        self.update_balance(self.account, current_balance="100.00", available_balance="90.00")
+
+        self.account.refresh_from_db()
+        self.assertEqual(self.account.available_balance, Decimal("90.00"))
+
+    def test_an_invalid_amount_is_rejected_without_touching_the_account(self):
+        response = self.update_balance(self.account, current_balance="not-a-number")
+
+        self.account.refresh_from_db()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self.account.current_balance, Decimal("4200.00"))
+
+    def test_re_running_for_the_same_date_overwrites_rather_than_stacks(self):
+        self.update_balance(self.account, current_balance="100.00")
+        self.update_balance(self.account, current_balance="200.00")
+
+        self.assertEqual(
+            AccountBalanceSnapshot.objects.filter(
+                account=self.account, as_of=date(2026, 8, 1)
+            ).count(),
+            1,
+        )
+        snapshot = AccountBalanceSnapshot.objects.get(
+            account=self.account, as_of=date(2026, 8, 1)
+        )
+        self.assertEqual(snapshot.current, Decimal("200.00"))
+
+    def test_it_is_gated_like_everything_else(self):
+        self.client.logout()
+
+        response = self.update_balance(self.account)
+
+        self.assertEqual(response.status_code, 403)
 
 
 class RuleManagementTests(SettingsTestCase):

--- a/finance/views_settings.py
+++ b/finance/views_settings.py
@@ -11,13 +11,16 @@ from django import forms
 from django.contrib import messages
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse_lazy
+from django.utils import timezone
 from django.utils.text import slugify
 from django.views.generic import CreateView, FormView, ListView, TemplateView, UpdateView
 
 from .access import FinanceAccessMixin
+from .dates import household_today
 from .models import (
     Account,
     AccountConnection,
+    BalanceSource,
     Budget,
     CategoryRule,
     ConnectionStatus,
@@ -30,7 +33,7 @@ from .models import (
 )
 from .providers.base import ProviderError
 from .providers.simplefin import claim_access_url
-from .services.sync import sync_connection
+from .services.sync import record_balance_snapshot, sync_connection
 from .services.widgets import WIDGET_CHOICES
 from .views import FinanceView
 from .views_dashboards import CHART_SECTION_CHOICES
@@ -297,6 +300,36 @@ class ConnectionDetailView(FinanceAccessMixin, TemplateView):
         return redirect("finance:connection_detail", pk=connection.pk)
 
 
+class BalanceUpdateForm(forms.Form):
+    """A one-off balance reading, typed in by hand — the lightweight
+    alternative to a full CSV balances import for a single account.
+
+    Deliberately a plain Form, not a ModelForm: saving it does more than set
+    two fields on the Account (see AccountUpdateView._update_balance), it also
+    records an AccountBalanceSnapshot so the reading feeds the same balance
+    history charts a sync or CSV import would.
+    """
+
+    as_of = forms.DateField(
+        label="Balance as of",
+        widget=forms.DateInput(attrs={"class": FIELD_CLASSES, "type": "date"}),
+    )
+    current_balance = forms.DecimalField(
+        label="Balance",
+        max_digits=12,
+        decimal_places=2,
+        widget=forms.NumberInput(attrs={"class": FIELD_CLASSES, "step": "0.01"}),
+        help_text="Signed the same way it reads everywhere else in the app — negative for a debt.",
+    )
+    available_balance = forms.DecimalField(
+        label="Available balance",
+        max_digits=12,
+        decimal_places=2,
+        required=False,
+        widget=forms.NumberInput(attrs={"class": FIELD_CLASSES, "step": "0.01"}),
+    )
+
+
 class AccountForm(forms.ModelForm):
     class Meta:
         model = Account
@@ -383,7 +416,49 @@ class AccountUpdateView(FinanceAccessMixin, UpdateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["page_title"] = f"Edit {self.object.name}"
+        context.setdefault(
+            "balance_form",
+            BalanceUpdateForm(initial={"as_of": household_today()}),
+        )
         return context
+
+    def post(self, request, *args, **kwargs):
+        self.object = self.get_object()
+
+        if request.POST.get("action") == "update_balance":
+            return self._update_balance(request)
+
+        return super().post(request, *args, **kwargs)
+
+    def _update_balance(self, request):
+        """A one-off manual reading — the lightweight alternative to a CSV
+        balances import for a single account, connected or not. For a
+        connected account this is only as durable as the next sync, which
+        will overwrite it with whatever the provider reports."""
+        account = self.object
+        balance_form = BalanceUpdateForm(request.POST)
+
+        if not balance_form.is_valid():
+            context = self.get_context_data(
+                form=AccountForm(instance=account), balance_form=balance_form
+            )
+            return self.render_to_response(context)
+
+        account.current_balance = balance_form.cleaned_data["current_balance"]
+        account.available_balance = balance_form.cleaned_data["available_balance"]
+        account.balance_as_of = timezone.now()
+        account.save(update_fields=["current_balance", "available_balance", "balance_as_of", "updated_at"])
+
+        record_balance_snapshot(
+            account,
+            as_of=balance_form.cleaned_data["as_of"],
+            current=account.current_balance,
+            available=account.available_balance,
+            source=BalanceSource.MANUAL,
+        )
+
+        messages.success(request, f"Updated {account.name}'s balance.")
+        return redirect(self.get_success_url())
 
     def form_valid(self, form):
         # current_balance is normalised (services.sync.normalise_balance) only


### PR DESCRIPTION
## Summary

- Every account's edit page (`Settings → account → edit`) now has an "Update balance" panel: enter a date, a balance, and optionally an available balance.
- On submit it updates `Account.current_balance` / `available_balance` / `balance_as_of` immediately, and records an `AccountBalanceSnapshot(source=BalanceSource.MANUAL)` for that date — the exact same effect a sync or a CSV balances import has, so it feeds the same Savings & Debt balance history charts (`analytics.balance_history`) without waiting on either.
- Available for **any** account, connected or manual, per explicit request. For a connected account the panel notes that this only lasts until the next sync, which will overwrite it with whatever the provider reports.
- Re-submitting for the same date overwrites that day's snapshot rather than stacking a duplicate (same `update_or_create` behavior `record_balance_snapshot` already uses for sync and CSV).

## Test plan

- [x] `manage.py test finance` — 505 tests, all passing (new `ManualBalanceUpdateTests`: account fields update, snapshot recorded as manual, works on a connected account, available balance optional, invalid amount rejected without touching the account, same-date re-submit overwrites rather than stacking, gated behind auth)
- [x] `manage.py makemigrations --check --dry-run` — no changes detected (no model changes)
- [x] `manage.py check` — no issues
- [x] `npm run tailwind:build` — no new classes needed
- [x] Verified locally in browser against seeded data: edited the connected "Student Loans" account, submitted a new balance, saw the success message and the updated balance/last-updated date on the Settings page, and confirmed the `AccountBalanceSnapshot` was written with `source=manual`

🤖 Generated with [Claude Code](https://claude.com/claude-code)