### PR TITLE
Move Hide chart into each card as a real button

### DIFF
--- a/finance/templates/finance/dashboards/_hide_chart_button.html
+++ b/finance/templates/finance/dashboards/_hide_chart_button.html
@@ -1,0 +1,15 @@
+{% comment %}
+  A "Hide chart" button for one section's card. Relies on `slug` and
+  `current_path` already being in context — both flow down for free from
+  charts.html's `{% for slug in chart_sections %}` loop, since none of the
+  includes between here and there use `only`.
+{% endcomment %}
+<form method="post" action="{{ current_path }}">
+  {% csrf_token %}
+  <input type="hidden" name="action" value="hide_section" />
+  <input type="hidden" name="section" value="{{ slug }}" />
+  <button type="submit"
+          class="shrink-0 rounded-button border border-border px-2.5 py-1 text-xs font-medium text-text-secondary transition hover:bg-muted hover:text-text-primary">
+    Hide chart
+  </button>
+</form>

--- a/finance/templates/finance/dashboards/charts.html
+++ b/finance/templates/finance/dashboards/charts.html
@@ -16,16 +16,6 @@
   {% for slug in chart_sections %}
     {% if section_has_data|get_item:slug %}
       <div class="mt-8">
-        <div class="flex justify-end">
-          <form method="post" action="{{ current_path }}">
-            {% csrf_token %}
-            <input type="hidden" name="action" value="hide_section" />
-            <input type="hidden" name="section" value="{{ slug }}" />
-            <button type="submit" class="text-xs text-text-muted underline decoration-dotted hover:text-text-secondary">
-              Hide chart
-            </button>
-          </form>
-        </div>
         {% include "finance/dashboards/sections/"|add:slug|add:".html" %}
       </div>
     {% endif %}

--- a/finance/templates/finance/dashboards/sections/accounts_list.html
+++ b/finance/templates/finance/dashboards/sections/accounts_list.html
@@ -10,7 +10,10 @@
   {% endif %}
 
   <section class="rounded-card border border-border bg-surface p-5">
-    <h2 class="text-sm font-semibold uppercase tracking-wide text-text-muted">Savings &amp; debt accounts</h2>
+    <div class="flex items-start justify-between gap-3">
+      <h2 class="text-sm font-semibold uppercase tracking-wide text-text-muted">Savings &amp; debt accounts</h2>
+      {% include "finance/dashboards/_hide_chart_button.html" %}
+    </div>
     <ul class="mt-4 divide-y divide-border">
       {% for account in savings_debt_accounts %}
         <li class="flex items-center justify-between gap-3 py-2.5">

--- a/finance/templates/finance/dashboards/sections/balances_over_time.html
+++ b/finance/templates/finance/dashboards/sections/balances_over_time.html
@@ -6,26 +6,29 @@
         <p class="mt-1 text-xs text-text-muted">Every account, signed the same way it reads everywhere else — a debt is negative.</p>
       </div>
 
-      <details class="rounded-button border border-border bg-background text-sm">
-        <summary class="cursor-pointer select-none px-3 py-2">
-          Accounts{% if selected_balances_accounts %} ({{ selected_balances_accounts|length }}){% endif %}
-        </summary>
-        <form method="get" class="max-h-56 space-y-1 overflow-y-auto border-t border-border p-2">
-          <input type="hidden" name="range" value="{{ selected_range }}" />
-          <input type="hidden" name="grain" value="{{ selected_grain }}" />
-          {% for account in selected_accounts %}<input type="hidden" name="account" value="{{ account }}" />{% endfor %}
-          {% for account in all_accounts %}
-            <label class="flex items-center gap-2 rounded px-1 py-1 text-xs hover:bg-muted/50">
-              <input type="checkbox" name="balances_account" value="{{ account.pk }}"
-                     {% if account.pk in selected_balances_accounts %}checked{% endif %} />
-              {{ account.name }}
-            </label>
-          {% endfor %}
-          <button type="submit" class="mt-1 w-full rounded-button bg-primary px-2 py-1.5 text-xs font-medium text-white hover:bg-primary-600">
-            Apply
-          </button>
-        </form>
-      </details>
+      <div class="flex items-start gap-2">
+        <details class="rounded-button border border-border bg-background text-sm">
+          <summary class="cursor-pointer select-none px-3 py-2">
+            Accounts{% if selected_balances_accounts %} ({{ selected_balances_accounts|length }}){% endif %}
+          </summary>
+          <form method="get" class="max-h-56 space-y-1 overflow-y-auto border-t border-border p-2">
+            <input type="hidden" name="range" value="{{ selected_range }}" />
+            <input type="hidden" name="grain" value="{{ selected_grain }}" />
+            {% for account in selected_accounts %}<input type="hidden" name="account" value="{{ account }}" />{% endfor %}
+            {% for account in all_accounts %}
+              <label class="flex items-center gap-2 rounded px-1 py-1 text-xs hover:bg-muted/50">
+                <input type="checkbox" name="balances_account" value="{{ account.pk }}"
+                       {% if account.pk in selected_balances_accounts %}checked{% endif %} />
+                {{ account.name }}
+              </label>
+            {% endfor %}
+            <button type="submit" class="mt-1 w-full rounded-button bg-primary px-2 py-1.5 text-xs font-medium text-white hover:bg-primary-600">
+              Apply
+            </button>
+          </form>
+        </details>
+        {% include "finance/dashboards/_hide_chart_button.html" %}
+      </div>
     </div>
 
     {% if balances_over_time_has_data %}

--- a/finance/templates/finance/dashboards/sections/budget_attainment.html
+++ b/finance/templates/finance/dashboards/sections/budget_attainment.html
@@ -1,6 +1,9 @@
 {% if spend_has_data %}
   <section class="mt-4 rounded-card border border-border bg-surface p-5">
-    <h2 class="text-sm font-semibold uppercase tracking-wide text-text-muted">Budget attainment over time</h2>
+    <div class="flex items-start justify-between gap-3">
+      <h2 class="text-sm font-semibold uppercase tracking-wide text-text-muted">Budget attainment over time</h2>
+      {% include "finance/dashboards/_hide_chart_button.html" %}
+    </div>
     {{ budget_series_json|json_script:"budget-series" }}
     <div class="mt-4 space-y-6">
       {% for budget in budgets %}

--- a/finance/templates/finance/dashboards/sections/large_transactions.html
+++ b/finance/templates/finance/dashboards/sections/large_transactions.html
@@ -1,7 +1,10 @@
 {% load finance_extras %}
 {% if large_transactions_has_data %}
   <section class="rounded-card border border-border bg-surface p-5">
-    <h2 class="text-sm font-semibold uppercase tracking-wide text-text-muted">Largest transactions</h2>
+    <div class="flex items-start justify-between gap-3">
+      <h2 class="text-sm font-semibold uppercase tracking-wide text-text-muted">Largest transactions</h2>
+      {% include "finance/dashboards/_hide_chart_button.html" %}
+    </div>
     <p class="mt-1 text-xs text-text-muted">The biggest one-off outflows in this window — worth a second look.</p>
     <ul class="mt-4 divide-y divide-border">
       {% for txn in large_transactions %}

--- a/finance/templates/finance/dashboards/sections/net_cash_flow.html
+++ b/finance/templates/finance/dashboards/sections/net_cash_flow.html
@@ -1,6 +1,9 @@
 {% if cash_flow_has_data %}
   <section class="mt-8 rounded-card border border-border bg-surface p-5">
-    <h2 class="text-sm font-semibold uppercase tracking-wide text-text-muted">Net cash flow</h2>
+    <div class="flex items-start justify-between gap-3">
+      <h2 class="text-sm font-semibold uppercase tracking-wide text-text-muted">Net cash flow</h2>
+      {% include "finance/dashboards/_hide_chart_button.html" %}
+    </div>
     <p class="mt-1 text-xs text-text-muted">Income minus spend, per period — above zero is cash building up.</p>
     <div class="mt-4 h-64">
       <canvas data-chart="bar" data-source="cash-flow" data-label="Net cash flow"></canvas>

--- a/finance/templates/finance/dashboards/sections/net_income.html
+++ b/finance/templates/finance/dashboards/sections/net_income.html
@@ -1,6 +1,9 @@
 {% if income_has_data %}
   <section class="mt-8 rounded-card border border-border bg-surface p-5">
-    <h2 class="text-sm font-semibold uppercase tracking-wide text-text-muted">Net income</h2>
+    <div class="flex items-start justify-between gap-3">
+      <h2 class="text-sm font-semibold uppercase tracking-wide text-text-muted">Net income</h2>
+      {% include "finance/dashboards/_hide_chart_button.html" %}
+    </div>
     <p class="mt-1 text-xs text-text-muted">
       Every deposit categorised as income, whether or not a payslip was imported for it.
     </p>

--- a/finance/templates/finance/dashboards/sections/net_worth.html
+++ b/finance/templates/finance/dashboards/sections/net_worth.html
@@ -1,6 +1,9 @@
 {% if net_worth_has_data %}
   <section class="rounded-card border border-border bg-surface p-5">
-    <h2 class="text-sm font-semibold uppercase tracking-wide text-text-muted">Net worth</h2>
+    <div class="flex items-start justify-between gap-3">
+      <h2 class="text-sm font-semibold uppercase tracking-wide text-text-muted">Net worth</h2>
+      {% include "finance/dashboards/_hide_chart_button.html" %}
+    </div>
     <p class="mt-1 text-xs text-text-muted">Everything you own minus everything you owe, day by day.</p>
     <div class="mt-4 h-64">
       <canvas data-chart="line" data-source="net-worth" data-label="Net worth"></canvas>

--- a/finance/templates/finance/dashboards/sections/recurring_expenses.html
+++ b/finance/templates/finance/dashboards/sections/recurring_expenses.html
@@ -1,6 +1,9 @@
 {% if recurring_expenses_has_data %}
   <section class="rounded-card border border-border bg-surface p-5">
-    <h2 class="text-sm font-semibold uppercase tracking-wide text-text-muted">Recurring expenses, over time</h2>
+    <div class="flex items-start justify-between gap-3">
+      <h2 class="text-sm font-semibold uppercase tracking-wide text-text-muted">Recurring expenses, over time</h2>
+      {% include "finance/dashboards/_hide_chart_button.html" %}
+    </div>
     <p class="mt-1 text-xs text-text-muted">
       Merchants with spend in at least three periods here — a subscription or a
       utility creeping up shows itself as its own line.

--- a/finance/templates/finance/dashboards/sections/spend_by_category.html
+++ b/finance/templates/finance/dashboards/sections/spend_by_category.html
@@ -1,6 +1,9 @@
 {% if spend_has_data %}
   <section class="mt-4 rounded-card border border-border bg-surface p-5">
-    <h2 class="text-sm font-semibold uppercase tracking-wide text-text-muted">By category</h2>
+    <div class="flex items-start justify-between gap-3">
+      <h2 class="text-sm font-semibold uppercase tracking-wide text-text-muted">By category</h2>
+      {% include "finance/dashboards/_hide_chart_button.html" %}
+    </div>
     <div class="mt-4 h-72">
       <canvas data-chart="doughnut" data-source="spend-by-category"></canvas>
     </div>

--- a/finance/templates/finance/dashboards/sections/spend_by_category_trend.html
+++ b/finance/templates/finance/dashboards/sections/spend_by_category_trend.html
@@ -1,6 +1,9 @@
 {% if spend_has_data %}
   <section class="mt-4 rounded-card border border-border bg-surface p-5">
-    <h2 class="text-sm font-semibold uppercase tracking-wide text-text-muted">Spend by category, over time</h2>
+    <div class="flex items-start justify-between gap-3">
+      <h2 class="text-sm font-semibold uppercase tracking-wide text-text-muted">Spend by category, over time</h2>
+      {% include "finance/dashboards/_hide_chart_button.html" %}
+    </div>
     <p class="mt-1 text-xs text-text-muted">Each line is a category, so a trend jumps out.</p>
     <div class="mt-4 h-72">
       <canvas data-chart="lines" data-source="spend-by-category-over-time"></canvas>

--- a/finance/templates/finance/dashboards/sections/spend_over_time.html
+++ b/finance/templates/finance/dashboards/sections/spend_over_time.html
@@ -4,7 +4,10 @@
   <p class="text-xs text-text-muted">total spend this window</p>
 
   <section class="mt-6 rounded-card border border-border bg-surface p-5">
-    <h2 class="text-sm font-semibold uppercase tracking-wide text-text-muted">Spend over time</h2>
+    <div class="flex items-start justify-between gap-3">
+      <h2 class="text-sm font-semibold uppercase tracking-wide text-text-muted">Spend over time</h2>
+      {% include "finance/dashboards/_hide_chart_button.html" %}
+    </div>
     <div class="mt-4 h-64">
       <canvas data-chart="bar" data-source="spend-over-time" data-label="Spend"></canvas>
     </div>

--- a/static/css/tailwind.css
+++ b/static/css/tailwind.css
@@ -1551,10 +1551,6 @@ video {
   align-items: stretch;
 }
 
-.justify-end {
-  justify-content: flex-end;
-}
-
 .justify-center {
   justify-content: center;
 }
@@ -2177,10 +2173,6 @@ video {
 
 .underline {
   text-decoration-line: underline;
-}
-
-.decoration-dotted {
-  text-decoration-style: dotted;
 }
 
 .underline-offset-4 {


### PR DESCRIPTION
## Summary

- The "Hide chart" control was a plain underlined text link, floating in a wrapper `<div>` above each card rather than being part of it.
- It's now a proper bordered button, placed inside each card's own header row next to the title (top-right) — the same spot on every section, including next to Balances over time's account filter.
- Extracted to one shared partial (`_hide_chart_button.html`) instead of duplicating the form/button markup in all 11 section templates. It relies on `slug` and `current_path` already being in scope from `charts.html`'s `{% for slug in chart_sections %}` loop — none of the includes between there and here use `only`, so both flow down for free.

## Test plan

- [x] `manage.py test finance` — 524 tests, all passing
- [x] `manage.py makemigrations --check --dry-run` — no changes detected
- [x] `manage.py check` — no issues
- [x] `npm run tailwind:build` — small diff (dropped the now-unused underline classes)
- [x] Verified locally in browser: every card now shows a real bordered "Hide chart" button in its header; confirmed the button is still correctly wired (posts the right section slug) after the markup move

🤖 Generated with [Claude Code](https://claude.com/claude-code)