### PR TITLE
Fix leaked template comment; simplify nav (Import styling, Help placement, ordering)

### DIFF
--- a/finance/templates/finance/partials/header.html
+++ b/finance/templates/finance/partials/header.html
@@ -19,18 +19,11 @@
         </a>
       {% endfor %}
       {% for item in secondary_nav_items %}
-        {% if item.is_button %}
-          <a href="{{ item.href }}"
-             class="rounded-button bg-primary px-3.5 py-2 text-xs font-medium text-white transition hover:bg-primary-600">
-            {{ item.label }}
-          </a>
-        {% else %}
-          <a href="{{ item.href }}"
-             class="transition hover:text-text-primary {% if item.is_active %}font-semibold text-text-primary{% endif %}"
-             {% if item.is_active %}aria-current="page"{% endif %}>
-            {{ item.label }}
-          </a>
-        {% endif %}
+        <a href="{{ item.href }}"
+           class="transition hover:text-text-primary {% if item.is_active %}font-semibold text-text-primary{% endif %}"
+           {% if item.is_active %}aria-current="page"{% endif %}>
+          {{ item.label }}
+        </a>
       {% endfor %}
     </nav>
 
@@ -54,6 +47,8 @@
            class="block px-4 py-2.5 text-sm text-text-secondary transition hover:bg-muted hover:text-text-primary">Alerts &amp; reports</a>
         <a href="{% url 'finance:preferences' %}" role="menuitem"
            class="block px-4 py-2.5 text-sm text-text-secondary transition hover:bg-muted hover:text-text-primary">Preferences</a>
+        <a href="{% url 'finance:help' %}" role="menuitem"
+           class="block px-4 py-2.5 text-sm text-text-secondary transition hover:bg-muted hover:text-text-primary">Help</a>
         <a href="{% url 'core:home' %}" role="menuitem"
            class="block border-t border-border px-4 py-2.5 text-sm text-text-muted transition hover:bg-muted hover:text-text-primary">Back to datamays.com</a>
 

--- a/finance/templates/finance/partials/nav_bottom.html
+++ b/finance/templates/finance/partials/nav_bottom.html
@@ -2,9 +2,11 @@
 {% finance_nav as nav_items %}
 {% finance_secondary_nav as secondary_nav_items %}
 
-{# Thumb-reachable tab bar. Mobile only — desktop uses the header nav. Mirrors
-   the header exactly (primary items, then Settings/Import/Help) so the two
-   surfaces never drift apart. #}
+{% comment %}
+  Thumb-reachable tab bar. Mobile only — desktop uses the header nav. Mirrors
+  the header exactly (primary items, then Import/Settings) so the two
+  surfaces never drift apart.
+{% endcomment %}
 <nav class="fixed inset-x-0 bottom-0 z-40 border-t border-border bg-background/95 pb-[env(safe-area-inset-bottom)] backdrop-blur md:hidden"
      aria-label="Primary">
   <ul class="mx-auto flex max-w-5xl items-stretch justify-between px-1">
@@ -23,13 +25,7 @@
         <a href="{{ item.href }}"
            class="flex flex-col items-center gap-1 px-1 py-2.5 text-[11px] font-medium transition {% if item.is_active %}text-accent{% else %}text-text-muted hover:text-text-secondary{% endif %}"
            {% if item.is_active %}aria-current="page"{% endif %}>
-          {% if item.is_button %}
-            <span class="rounded-full bg-primary p-1 text-white">
-              {% include "finance/icons/"|add:item.icon|add:".html" %}
-            </span>
-          {% else %}
-            {% include "finance/icons/"|add:item.icon|add:".html" %}
-          {% endif %}
+          {% include "finance/icons/"|add:item.icon|add:".html" %}
           <span>{{ item.label }}</span>
         </a>
       </li>

--- a/finance/templatetags/finance_nav.py
+++ b/finance/templatetags/finance_nav.py
@@ -14,9 +14,16 @@ PRIMARY_NAV = [
 
 # App navigation that isn't daily-use, but still belongs at the top level
 # rather than buried in the account dropdown (which is reserved for
-# user-specific things — preferences, alerts, sign out). Shown on both the
-# desktop header and the mobile tab bar, so the two never drift apart.
+# user-specific things — preferences, alerts, help, sign out). Shown on both
+# the desktop header and the mobile tab bar, so the two never drift apart.
+# Import before Settings, per an explicit "Settings at the far right" ask.
 SECONDARY_NAV = [
+    {
+        "url_name": "imports",
+        "label": "Import data",
+        "icon": "upload",
+        "related": ["import_schemas", "import_upload", "import_map", "import_preview"],
+    },
     {
         "url_name": "settings",
         "label": "Settings",
@@ -27,14 +34,6 @@ SECONDARY_NAV = [
             "account_create", "account_edit", "rules",
         ],
     },
-    {
-        "url_name": "imports",
-        "label": "Import data",
-        "icon": "upload",
-        "related": ["import_schemas", "import_upload", "import_map", "import_preview"],
-        "is_button": True,
-    },
-    {"url_name": "help", "label": "Help", "icon": "help"},
 ]
 
 
@@ -60,5 +59,6 @@ def finance_nav(context):
 
 @register.simple_tag(takes_context=True)
 def finance_secondary_nav(context):
-    """Desktop-header-only nav items (Settings, Import, Help)."""
+    """Secondary nav items (Import, Settings) — shown on both the desktop
+    header and the mobile tab bar, after the primary items."""
     return _resolve(context, SECONDARY_NAV)

--- a/finance/tests/test_navigation.py
+++ b/finance/tests/test_navigation.py
@@ -15,33 +15,38 @@ class HeaderNavTests(TestCase):
         session["otp_device_id"] = TOTPDevice.objects.get(user=self.user).persistent_id
         session.save()
 
-    def test_settings_help_and_import_are_top_level_nav_links(self):
+    def test_settings_and_import_are_top_level_nav_links(self):
         response = self.client.get(reverse("finance:home"))
         body = response.content.decode()
         settings_href = reverse("finance:settings")
-        help_href = reverse("finance:help")
         imports_href = reverse("finance:imports")
 
-        for href in [settings_href, help_href, imports_href]:
+        for href in [settings_href, imports_href]:
             self.assertIn(f'href="{href}"', body)
 
-    def test_the_dropdown_only_has_user_specific_items(self):
+    def test_help_is_not_a_top_level_nav_link(self):
+        response = self.client.get(reverse("finance:home"))
+
+        secondary = response.context["secondary_nav_items"]
+        self.assertNotIn("help", [item["url_name"] for item in secondary])
+
+    def test_the_dropdown_has_help_and_user_specific_items(self):
         response = self.client.get(reverse("finance:home"))
         body = response.content.decode()
 
         # Bounded to the header: the dropdown lives entirely inside it, and
         # both the primary/secondary nav and the mobile tab bar (which also
-        # legitimately says "Settings" and "Help") live outside it.
+        # legitimately says "Settings") live outside it.
         dropdown_start = body.index('role="menu"')
         dropdown_end = body.index("</header>", dropdown_start)
         dropdown = body[dropdown_start:dropdown_end]
 
         self.assertIn("Alerts", dropdown)
         self.assertIn("Preferences", dropdown)
+        self.assertIn(">Help<", dropdown)
         self.assertIn("Back to datamays.com", dropdown)
         self.assertIn("Sign out", dropdown)
         self.assertNotIn(">Settings<", dropdown)
-        self.assertNotIn(">Help<", dropdown)
 
     def test_settings_nav_item_is_active_on_a_settings_subpage(self):
         response = self.client.get(reverse("finance:rules"))
@@ -58,29 +63,52 @@ class HeaderNavTests(TestCase):
         self.assertIn("Import data", body)
         self.assertIn(f'href="{reverse("finance:imports")}"', body)
 
+    def test_settings_comes_after_import_in_the_desktop_nav(self):
+        response = self.client.get(reverse("finance:home"))
+
+        secondary = response.context["secondary_nav_items"]
+        self.assertEqual(
+            [item["url_name"] for item in secondary], ["imports", "settings"]
+        )
+
     def test_the_mobile_tab_bar_matches_the_desktop_nav(self):
         # The bug report this guards against: the footer tab bar only ever
-        # rendered PRIMARY_NAV, so Settings/Import/Help were reachable on
-        # desktop but invisible on a phone.
+        # rendered PRIMARY_NAV, so Settings/Import were reachable on desktop
+        # but invisible on a phone.
         response = self.client.get(reverse("finance:home"))
         body = response.content.decode()
 
         tab_bar_start = body.index('aria-label="Primary"')
         tab_bar = body[tab_bar_start:]
 
-        for href in [
-            reverse("finance:settings"),
-            reverse("finance:imports"),
-            reverse("finance:help"),
-        ]:
+        for href in [reverse("finance:settings"), reverse("finance:imports")]:
             self.assertIn(f'href="{href}"', tab_bar)
 
-    def test_the_import_tab_gets_a_call_to_action_treatment(self):
+    def test_settings_comes_after_import_in_the_mobile_tab_bar(self):
+        response = self.client.get(reverse("finance:home"))
+        body = response.content.decode()
+
+        tab_bar_start = body.index('aria-label="Primary"')
+        tab_bar = body[tab_bar_start:]
+
+        imports_index = tab_bar.index(f'href="{reverse("finance:imports")}"')
+        settings_index = tab_bar.index(f'href="{reverse("finance:settings")}"')
+        self.assertLess(imports_index, settings_index)
+
+    def test_import_does_not_get_a_call_to_action_treatment(self):
+        # Explicitly dropped: it looked out of place next to the plain
+        # icon/text nav items everywhere else.
         response = self.client.get(reverse("finance:home"))
         body = response.content.decode()
 
         tab_bar_start = body.index('aria-label="Primary"')
         imports_index = body.index(f'href="{reverse("finance:imports")}"', tab_bar_start)
 
-        # The blue chip wrapping the icon, not just plain matching text color.
-        self.assertIn("bg-primary", body[imports_index:imports_index + 400])
+        self.assertNotIn("bg-primary", body[imports_index:imports_index + 400])
+
+    def test_no_stray_template_comment_leaks_into_the_page(self):
+        # Regression: a {# #} comment spanning multiple lines is not stripped
+        # by Django and was rendering as literal text on every page.
+        response = self.client.get(reverse("finance:qfrs"))
+
+        self.assertNotContains(response, "Thumb-reachable")

--- a/static/css/tailwind.css
+++ b/static/css/tailwind.css
@@ -1851,10 +1851,6 @@ video {
   background-color: rgb(255 255 255 / var(--tw-bg-opacity, 1));
 }
 
-.p-1 {
-  padding: 0.25rem;
-}
-
 .p-10 {
   padding: 2.5rem;
 }


### PR DESCRIPTION
## Summary

1. **Fixed the QFRs rendering bug**: a Django `{# #}` comment spanning multiple lines is not stripped by the template engine (it only works as a same-line comment) — its literal text was rendering on every page, most visibly on QFRs right above the page content. Replaced with `{% comment %}...{% endcomment %}`, which does support multiple lines. Added a regression test.
2. **Dropped Import data's blue call-to-action styling** entirely, per feedback that it looked out of place next to the plain icon/text items around it. It now matches Settings/Home/Activity/etc. exactly on both the header and the mobile tab bar.
3. **Moved Help back into the account dropdown**, off the top-level nav — the mobile tab bar had grown to six buttons, too many for a thumb bar.
4. **Reordered the remaining secondary items** so Settings sits at the far right, after Import data, on both the desktop header and the mobile tab bar (now: Home, Activity, Charts, QFRs, Import data, Settings).

## Test plan

- [x] `manage.py test finance` — 528 tests, all passing (updated `test_navigation.py` for the new dropdown/order/no-CTA expectations, added a regression test asserting "Thumb-reachable" never renders on the QFRs page)
- [x] `manage.py makemigrations --check --dry-run` — no changes detected
- [x] `manage.py check` — no issues
- [x] `npm run tailwind:build` — small diff (dropped unused CTA classes)
- [x] Verified locally in browser: QFRs page no longer shows the stray comment text; bottom tab bar shows Home/Activity/Charts/QFRs/Import data/Settings with no highlight on Import; desktop header matches; account dropdown shows Alerts & reports/Preferences/Help/Back to site/Sign out

🤖 Generated with [Claude Code](https://claude.com/claude-code)