### PR TITLE
Standardize on "categorize" (American spelling) site-wide

### DIFF
--- a/datamays/settings.py
+++ b/datamays/settings.py
@@ -260,11 +260,11 @@ FIELD_ENCRYPTION_KEYS = [
 # UTC gets wrong every evening after about 7pm Chicago time.
 FINANCE_TIME_ZONE = os.getenv("FINANCE_TIME_ZONE", "America/Chicago")
 
-# Transaction categorisation. Absent a key the deterministic steps still run
+# Transaction categorization. Absent a key the deterministic steps still run
 # and anything unmatched queues for review, so the app degrades rather than
 # breaks.
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")
-FINANCE_CATEGORISER_MODEL = os.getenv("FINANCE_CATEGORISER_MODEL", "gpt-4o-mini")
+FINANCE_CATEGORIZER_MODEL = os.getenv("FINANCE_CATEGORIZER_MODEL", "gpt-4o-mini")
 FINANCE_QFR_MODEL = os.getenv("FINANCE_QFR_MODEL", "gpt-4o-mini")
 
 CONTACT_RECIPIENT_EMAIL = os.getenv("CONTACT_RECIPIENT_EMAIL")

--- a/finance/RUNBOOK.md
+++ b/finance/RUNBOOK.md
@@ -27,8 +27,8 @@ manager, not this repo.
 |---|---|---|
 | `FIELD_ENCRYPTION_KEYS` | Encrypts provider credentials | Yes |
 | `SECRET_KEY` | Signs sessions — the app refuses to boot without it outside dev | Yes |
-| `OPENAI_API_KEY` | Transaction categorisation and QFR narratives | No — both degrade gracefully without it |
-| `FINANCE_CATEGORISER_MODEL` | Defaults to `gpt-4o-mini` | No |
+| `OPENAI_API_KEY` | Transaction categorization and QFR narratives | No — both degrade gracefully without it |
+| `FINANCE_CATEGORIZER_MODEL` | Defaults to `gpt-4o-mini` | No |
 | `FINANCE_QFR_MODEL` | Defaults to `gpt-4o-mini` | No |
 | `FINANCE_TIME_ZONE` | What "today" means for periods and alerts. Defaults to `America/Chicago` | No |
 | `EMAIL_HOST_USER` / `EMAIL_HOST_PASSWORD` | Alerts and reports | Only if you want email |
@@ -73,7 +73,7 @@ Add the Heroku Scheduler add-on, then create exactly two jobs:
 | Daily (pick an early-morning UTC time) | `python manage.py finance_daily` |
 
 **Hourly** syncs day-to-day accounts (checking, savings, money market, credit
-cards), categorises what arrived, rolls up budgets, then evaluates alerts. The
+cards), categorizes what arrived, rolls up budgets, then evaluates alerts. The
 order matters — alerts must see fresh budget numbers.
 
 **Daily** syncs *everything* including loans and the mortgage, snapshots
@@ -126,7 +126,7 @@ already-negative rather than as a positive amount owed. Untick
 *"Most institutions report a debt as a positive amount owed"* on that account
 in **Settings → Accounts**. Don't edit data to compensate.
 
-**Transactions aren't categorised.** Check `OPENAI_API_KEY` is set. Without it
+**Transactions aren't categorized.** Check `OPENAI_API_KEY` is set. Without it
 everything still runs — rules and remembered merchants apply — and the rest
 queues in **Activity → needs review**. To re-run:
 

--- a/finance/management/commands/categorize_transactions.py
+++ b/finance/management/commands/categorize_transactions.py
@@ -1,12 +1,12 @@
 from django.core.management.base import BaseCommand
 
 from finance.models import Transaction
-from finance.services.categorize import categorise_transactions
+from finance.services.categorize import categorize_transactions
 
 
 class Command(BaseCommand):
     help = (
-        "Categorise transactions that have no category yet. Rules and "
+        "Categorize transactions that have no category yet. Rules and "
         "remembered merchants run first; only genuinely new merchants reach "
         "the classifier."
     )
@@ -15,7 +15,7 @@ class Command(BaseCommand):
         parser.add_argument(
             "--recategorize",
             action="store_true",
-            help="Also revisit transactions already categorised by the classifier.",
+            help="Also revisit transactions already categorized by the classifier.",
         )
         parser.add_argument(
             "--no-transfers",
@@ -38,7 +38,7 @@ class Command(BaseCommand):
             )
             queryset = base[: options["limit"]]
 
-        summary = categorise_transactions(
+        summary = categorize_transactions(
             queryset=queryset, detect_transfers=not options["no_transfers"]
         )
 

--- a/finance/management/commands/finance_daily.py
+++ b/finance/management/commands/finance_daily.py
@@ -5,7 +5,7 @@ from django.core.management.base import BaseCommand
 class Command(BaseCommand):
     help = (
         "The daily chain: sync everything including slow-moving accounts, "
-        "categorise, snapshot balances, roll up budgets, and send due reports."
+        "categorize, snapshot balances, roll up budgets, and send due reports."
     )
 
     STEPS = [

--- a/finance/management/commands/finance_hourly.py
+++ b/finance/management/commands/finance_hourly.py
@@ -4,12 +4,12 @@ from django.core.management.base import BaseCommand
 
 class Command(BaseCommand):
     help = (
-        "The hourly chain: sync day-to-day accounts, categorise what arrived, "
+        "The hourly chain: sync day-to-day accounts, categorize what arrived, "
         "roll up budgets, then evaluate alerts. Wired to Heroku Scheduler."
     )
 
     # Order matters: alerts must see freshly rolled-up budgets, and budgets
-    # must see freshly categorised transactions.
+    # must see freshly categorized transactions.
     STEPS = [
         ("sync_accounts", {"high_frequency_only": True}),
         ("categorize_transactions", {}),

--- a/finance/providers/base.py
+++ b/finance/providers/base.py
@@ -1,7 +1,7 @@
 """The boundary between an outside financial institution and our data model.
 
 Adapters do one job: turn whatever a provider returns into the normalised
-payloads below. Everything downstream — sync, categorisation, dashboards —
+payloads below. Everything downstream — sync, categorization, dashboards —
 depends on the conventions in `finance.models.base` already holding, so this is
 the only layer allowed to reason about a provider's sign quirks or date
 formats. Adding a second provider later should mean writing one adapter and

--- a/finance/services/analytics.py
+++ b/finance/services/analytics.py
@@ -99,15 +99,15 @@ def spend_filter() -> Q:
 
     Excludes income and transfers, but *keeps* transactions with no category
     yet. Requiring an expense category silently dropped everything the
-    categoriser had not reached — and since the hourly chain isolates step
-    failures, a broken categorise run would have made the dashboards
+    categorizer had not reached — and since the hourly chain isolates step
+    failures, a broken categorize run would have made the dashboards
     under-report spend while looking perfectly healthy.
 
     A positive amount against an expense category counts too — a refund or a
     credit posted as its own transaction should net back against the outflow
     it corrects, not sit invisibly outside every spend total just because its
     sign differs from the purchase. This is deliberately narrower than "any
-    positive amount, any category": an *uncategorised* positive transaction
+    positive amount, any category": an *uncategorized* positive transaction
     is far more likely to be income the classifier hasn't reached yet than a
     refund, so that bucket keeps the original amount__lt=0 requirement.
     Aggregates built on this Q floor a negative net (more refunded than
@@ -214,7 +214,7 @@ def spend_by_category(start, end, *, account_ids=None, limit=10):
         name = (
             row["category__parent__name"]
             or row["category__name"]
-            or "Not yet categorised"
+            or "Not yet categorized"
         )
         grouped[name] = grouped.get(name, Decimal("0")) + -row["total"]
 
@@ -257,8 +257,8 @@ def income_filter() -> Q:
     """What counts as income, as a reusable Q — the mirror image of
     spend_filter(). Requires an explicit Income-kind category rather than
     "any positive amount," the same conservative choice spend_filter() makes
-    in the other direction: a deposit that hasn't been categorised yet is
-    just as likely to be an uncategorised refund as it is income, so it's
+    in the other direction: a deposit that hasn't been categorized yet is
+    just as likely to be an uncategorized refund as it is income, so it's
     left out until the classifier (or a person) says which."""
     return Q(is_transfer=False, amount__gt=0, category__kind=CategoryKind.INCOME)
 
@@ -266,7 +266,7 @@ def income_filter() -> Q:
 def net_income_over_time(start, end, *, grain="monthly", account_ids=None):
     """Net income per period, straight from deposits — no payslip required.
 
-    The primary read of "how much came in": every income-categorised deposit
+    The primary read of "how much came in": every income-categorized deposit
     counts, whether or not a payslip was ever imported for it. This is what
     makes the Income dashboard work for a household member whose pay never
     gets a detailed payslip import — see income_over_time() for the
@@ -368,7 +368,7 @@ def spend_by_category_over_time(start, end, *, grain="monthly", account_ids=None
         name = (
             row["category__parent__name"]
             or row["category__name"]
-            or "Not yet categorised"
+            or "Not yet categorized"
         )
         per_bucket = per_category.setdefault(name, {})
         amount = -row["total"]

--- a/finance/services/categorize.py
+++ b/finance/services/categorize.py
@@ -45,7 +45,7 @@ TRANSFER_WINDOW_DAYS = 4
 
 
 @dataclass
-class CategorisationSummary:
+class CategorizationSummary:
     transfers: int = 0
     by_rule: int = 0
     by_memo: int = 0
@@ -163,15 +163,15 @@ def remember_merchant(merchant_key, category, user=None):
     return memo
 
 
-def categorise_transactions(queryset=None, *, classifier=None, detect_transfers=True):
-    """Run the pipeline over uncategorised transactions.
+def categorize_transactions(queryset=None, *, classifier=None, detect_transfers=True):
+    """Run the pipeline over uncategorized transactions.
 
     Deliberately not wrapped in a single transaction. The classifier step makes
     a network call, and holding a database transaction open across it would pin
     a connection for as long as the provider takes to answer — on a small
     Postgres plan that is a real availability risk.
     """
-    summary = CategorisationSummary()
+    summary = CategorizationSummary()
 
     if detect_transfers:
         summary.transfers = find_transfer_pairs()
@@ -217,7 +217,7 @@ def categorise_transactions(queryset=None, *, classifier=None, detect_transfers=
         if merchant_key:
             awaiting_classifier.setdefault(merchant_key, []).append(txn)
         else:
-            _assign_uncategorised(txn)
+            _assign_uncategorized(txn)
             summary.unmatched += 1
 
     if awaiting_classifier:
@@ -279,7 +279,7 @@ def _run_classifier(awaiting, classifier, summary):
             continue
 
         for txn in transactions:
-            _assign_uncategorised(txn)
+            _assign_uncategorized(txn)
             summary.unmatched += 1
             summary.needs_review += 1
 
@@ -300,7 +300,7 @@ def _assign(txn, category, source, confidence, needs_review=False):
     )
 
 
-def _assign_uncategorised(txn):
+def _assign_uncategorized(txn):
     """Park a transaction in the review queue rather than leaving it invisible."""
     category = Category.objects.filter(slug=UNCATEGORIZED_SLUG).first()
 

--- a/finance/services/classifier.py
+++ b/finance/services/classifier.py
@@ -1,4 +1,4 @@
-"""The LLM step of categorisation, kept behind a small interface.
+"""The LLM step of categorization, kept behind a small interface.
 
 Only reached for merchants that no rule and no remembered decision covers, so
 in steady state this runs on a handful of genuinely new merchants a week
@@ -18,11 +18,11 @@ logger = logging.getLogger(__name__)
 
 BATCH_SIZE = 40
 
-# Without this the client waits indefinitely. The categoriser runs from the
+# Without this the client waits indefinitely. The categorizer runs from the
 # hourly chain, so a hung request would stall every later step behind it.
 REQUEST_TIMEOUT_SECONDS = 45
 
-SYSTEM_PROMPT = """You categorise personal bank transactions for a two-person household.
+SYSTEM_PROMPT = """You categorize personal bank transactions for a two-person household.
 
 You will get a list of merchant descriptions and a list of allowed categories.
 Assign each merchant exactly one category slug from the list.
@@ -66,7 +66,7 @@ class NullClassifier(Classifier):
 class OpenAIClassifier(Classifier):
     def __init__(self, api_key=None, model=None):
         self.api_key = api_key or getattr(settings, "OPENAI_API_KEY", "")
-        self.model = model or getattr(settings, "FINANCE_CATEGORISER_MODEL", "gpt-4o-mini")
+        self.model = model or getattr(settings, "FINANCE_CATEGORIZER_MODEL", "gpt-4o-mini")
 
     def classify(self, merchant_keys, categories):
         if not merchant_keys or not self.api_key:
@@ -81,7 +81,7 @@ class OpenAIClassifier(Classifier):
                 results.extend(self._classify_batch(batch, categories))
             except Exception:  # noqa: BLE001
                 # A classifier outage must not fail the sync. The affected
-                # transactions stay uncategorised and land in the review queue.
+                # transactions stay uncategorized and land in the review queue.
                 logger.exception("Classifier batch failed; leaving %d for review", len(batch))
 
         return results

--- a/finance/services/reports.py
+++ b/finance/services/reports.py
@@ -146,7 +146,7 @@ def build_sections(report, start, end):
         blocks.append(
             (
                 "Needs review",
-                f"  {count} transaction{'s' if count != 1 else ''} waiting to be categorised."
+                f"  {count} transaction{'s' if count != 1 else ''} waiting to be categorized."
                 if count
                 else "  Nothing waiting.",
             )

--- a/finance/services/rollups.py
+++ b/finance/services/rollups.py
@@ -55,7 +55,7 @@ def spend_for(budget: Budget, start, end) -> Decimal:
 
     Budget categories are always expense-kind by construction (see
     BudgetForm), so there's no equivalent here of analytics.spend_filter()'s
-    care around uncategorised positive amounts being mistaken for a refund —
+    care around uncategorized positive amounts being mistaken for a refund —
     every category in category_ids was deliberately chosen as spending.
     """
     category_ids = expand_categories(budget.categories.all())

--- a/finance/templates/finance/dashboards/sections/net_income.html
+++ b/finance/templates/finance/dashboards/sections/net_income.html
@@ -5,7 +5,7 @@
       {% include "finance/dashboards/_hide_chart_button.html" %}
     </div>
     <p class="mt-1 text-xs text-text-muted">
-      Every deposit categorised as income, whether or not a payslip was imported for it.
+      Every deposit categorized as income, whether or not a payslip was imported for it.
     </p>
     <div class="mt-4 h-64">
       <canvas data-chart="bar" data-source="net-income" data-label="Net income"></canvas>

--- a/finance/templates/finance/help.html
+++ b/finance/templates/finance/help.html
@@ -36,7 +36,7 @@
       quarterly, or annually — whichever the selected range actually
       covers), except Balances over time and budget attainment, which follow
       their own daily or budget-anchored timelines. Net income counts every
-      deposit categorised as income, whether or not a payslip was ever
+      deposit categorized as income, whether or not a payslip was ever
       imported for it; gross pay and tax only show up as optional extra
       detail where a payslip has been imported. Recurring expenses tracks
       merchants with spend in at least three periods in the window — a

--- a/finance/tests/test_categorize.py
+++ b/finance/tests/test_categorize.py
@@ -1,4 +1,4 @@
-"""The categorisation pipeline.
+"""The categorization pipeline.
 
 The classifier is always a stub here — no test makes a network call.
 """
@@ -21,7 +21,7 @@ from finance.models import (
 )
 from finance.services.categorize import (
     REVIEW_THRESHOLD,
-    categorise_transactions,
+    categorize_transactions,
     confirm_category,
     find_transfer_pairs,
 )
@@ -91,7 +91,7 @@ class RuleTests(PipelineTestCase):
         CategoryRule.objects.create(pattern="marianos", category=self.groceries)
         txn = make_transaction(self.checking, description_raw="MARIANOS #1234 CHICAGO IL")
 
-        categorise_transactions(classifier=StubClassifier())
+        categorize_transactions(classifier=StubClassifier())
 
         txn.refresh_from_db()
         self.assertEqual(txn.category, self.groceries)
@@ -104,7 +104,7 @@ class RuleTests(PipelineTestCase):
         txn = make_transaction(self.checking, description_raw="MARIANOS #1234")
 
         classifier = StubClassifier({"marianos": ("food-restaurants", 0.99)})
-        categorise_transactions(classifier=classifier)
+        categorize_transactions(classifier=classifier)
 
         txn.refresh_from_db()
         self.assertEqual(txn.category, self.groceries)
@@ -116,7 +116,7 @@ class RuleTests(PipelineTestCase):
         CategoryRule.objects.create(pattern="coffee", category=self.groceries, priority=50)
 
         txn = make_transaction(self.checking, description_raw="BLUE BOTTLE COFFEE")
-        categorise_transactions(classifier=StubClassifier())
+        categorize_transactions(classifier=StubClassifier())
 
         txn.refresh_from_db()
         self.assertEqual(txn.category, self.coffee)
@@ -130,7 +130,7 @@ class MemoTests(PipelineTestCase):
         txn = make_transaction(self.checking, description_raw="MARIANOS #5678 CHICAGO IL")
 
         classifier = StubClassifier()
-        categorise_transactions(classifier=classifier)
+        categorize_transactions(classifier=classifier)
 
         txn.refresh_from_db()
         self.assertEqual(txn.category, self.groceries)
@@ -143,7 +143,7 @@ class MemoTests(PipelineTestCase):
         )
         make_transaction(self.checking, description_raw="MARIANOS #1")
 
-        categorise_transactions(classifier=StubClassifier())
+        categorize_transactions(classifier=StubClassifier())
 
         memo.refresh_from_db()
         self.assertEqual(memo.hit_count, 1)
@@ -155,7 +155,7 @@ class ClassifierTests(PipelineTestCase):
         txn = make_transaction(self.checking, description_raw="BLUE BOTTLE COFFEE 4471")
         key = normalise_merchant(txn.description_raw)
 
-        categorise_transactions(classifier=StubClassifier({key: ("food-coffee", 0.95)}))
+        categorize_transactions(classifier=StubClassifier({key: ("food-coffee", 0.95)}))
 
         txn.refresh_from_db()
         self.assertEqual(txn.category, self.coffee)
@@ -167,7 +167,7 @@ class ClassifierTests(PipelineTestCase):
         txn = make_transaction(self.checking, description_raw="ACME HOLDINGS LLC")
         key = normalise_merchant(txn.description_raw)
 
-        categorise_transactions(
+        categorize_transactions(
             classifier=StubClassifier({key: ("food-coffee", REVIEW_THRESHOLD - 0.2)})
         )
 
@@ -186,7 +186,7 @@ class ClassifierTests(PipelineTestCase):
             )
 
         classifier = StubClassifier()
-        categorise_transactions(classifier=classifier)
+        categorize_transactions(classifier=classifier)
 
         self.assertEqual(len(classifier.calls), 1)
         self.assertEqual(len(classifier.calls[0]), 1)
@@ -194,7 +194,7 @@ class ClassifierTests(PipelineTestCase):
     def test_unclassified_transactions_land_in_the_review_queue(self):
         txn = make_transaction(self.checking, description_raw="MYSTERY VENDOR XYZ")
 
-        categorise_transactions(classifier=StubClassifier())
+        categorize_transactions(classifier=StubClassifier())
 
         txn.refresh_from_db()
         self.assertEqual(txn.category.slug, UNCATEGORIZED_SLUG)
@@ -235,7 +235,7 @@ class ClassifierTests(PipelineTestCase):
             self.checking, description_raw="MYSTERY LLC", amount=Decimal("-9.00")
         )
 
-        categorise_transactions(classifier=NullClassifier())
+        categorize_transactions(classifier=NullClassifier())
 
         ruled.refresh_from_db()
         unknown.refresh_from_db()
@@ -322,7 +322,7 @@ class TransferTests(PipelineTestCase):
         make_transaction(self.savings, amount=Decimal("500.00"))
 
         classifier = StubClassifier()
-        summary = categorise_transactions(classifier=classifier)
+        summary = categorize_transactions(classifier=classifier)
 
         self.assertEqual(summary.transfers, 1)
         self.assertEqual(classifier.calls, [])
@@ -345,7 +345,7 @@ class ConfirmationTests(PipelineTestCase):
         self.assertEqual(memo.category, self.coffee)
         self.assertEqual(memo.confirmed_by, user)
 
-    def test_a_confirmed_merchant_categorises_future_transactions_automatically(self):
+    def test_a_confirmed_merchant_categorizes_future_transactions_automatically(self):
         first = make_transaction(self.checking, description_raw="BLUE BOTTLE COFFEE 4471")
         confirm_category(first, self.coffee)
 
@@ -357,7 +357,7 @@ class ConfirmationTests(PipelineTestCase):
         )
 
         classifier = StubClassifier()
-        categorise_transactions(classifier=classifier)
+        categorize_transactions(classifier=classifier)
 
         later.refresh_from_db()
         self.assertEqual(later.category, self.coffee)
@@ -368,7 +368,7 @@ class ConfirmationTests(PipelineTestCase):
         confirm_category(txn, self.coffee, remember=False)
 
         CategoryRule.objects.create(pattern="marianos", category=self.groceries)
-        categorise_transactions(classifier=StubClassifier())
+        categorize_transactions(classifier=StubClassifier())
 
         txn.refresh_from_db()
         self.assertEqual(txn.category, self.coffee)
@@ -381,7 +381,7 @@ class ClassifierIsolationTests(TransactionTestCase):
     transaction, which would mask exactly the thing being asserted.
     """
 
-    def test_categorisation_does_not_hold_a_transaction_across_the_call(self):
+    def test_categorization_does_not_hold_a_transaction_across_the_call(self):
         from django.db import transaction as db_transaction
 
         call_command("seed_finance_categories", verbosity=0)
@@ -397,7 +397,7 @@ class ClassifierIsolationTests(TransactionTestCase):
                 )
                 return []
 
-        categorise_transactions(classifier=RecordingClassifier())
+        categorize_transactions(classifier=RecordingClassifier())
 
         # A held transaction pins a database connection for as long as the
         # provider takes to answer.

--- a/finance/tests/test_dashboards.py
+++ b/finance/tests/test_dashboards.py
@@ -115,15 +115,15 @@ class SpendAnalyticsTests(AnalyticsTestCase):
 
         self.assertEqual(result["values"], [70.0])
 
-    def test_a_positive_uncategorised_transaction_is_not_treated_as_a_refund(self):
-        # Uncategorised is far more likely to be income the classifier
+    def test_a_positive_uncategorized_transaction_is_not_treated_as_a_refund(self):
+        # Uncategorized is far more likely to be income the classifier
         # hasn't reached yet than a refund -- it must not net against spend.
         self.spend("-100.00", self.groceries, 5)
         make_transaction(
             self.checking,
             posted_on=date(2026, 4, 6),
             amount=Decimal("3000.00"),
-            description_raw="UNCATEGORISED DEPOSIT",
+            description_raw="UNCATEGORIZED DEPOSIT",
             category=None,
         )
 
@@ -283,7 +283,7 @@ class IncomeAnalyticsTests(AnalyticsTestCase):
 
 
 class NetIncomeAnalyticsTests(AnalyticsTestCase):
-    """The primary income figure — every income-categorised deposit, no
+    """The primary income figure — every income-categorized deposit, no
     payslip required. This is what makes the Income dashboard work for a
     household member whose pay never gets a detailed payslip import."""
 
@@ -335,15 +335,15 @@ class NetIncomeAnalyticsTests(AnalyticsTestCase):
 
         self.assertEqual(result["values"], [])
 
-    def test_an_uncategorised_deposit_is_not_assumed_to_be_income(self):
+    def test_an_uncategorized_deposit_is_not_assumed_to_be_income(self):
         # Symmetric with spend_filter()'s caution in the other direction: an
-        # uncategorised positive amount could just as easily be an
-        # uncategorised refund.
+        # uncategorized positive amount could just as easily be an
+        # uncategorized refund.
         make_transaction(
             self.checking,
             posted_on=date(2026, 4, 15),
             amount=Decimal("3400.00"),
-            description_raw="UNCATEGORISED DEPOSIT",
+            description_raw="UNCATEGORIZED DEPOSIT",
             category=None,
         )
 
@@ -989,7 +989,7 @@ class QuarterlyAndAnnualGrainAnalyticsTests(AnalyticsTestCase):
         )
 
 
-class UncategorisedSpendTests(TestCase):
+class UncategorizedSpendTests(TestCase):
     """Requiring an expense category silently dropped spend from every total."""
 
     def setUp(self):
@@ -1001,12 +1001,12 @@ class UncategorisedSpendTests(TestCase):
 
         Transaction.objects.create(
             account=self.account, posted_on=date(2026, 4, 10),
-            amount=Decimal("-100.00"), description_raw="CATEGORISED",
+            amount=Decimal("-100.00"), description_raw="CATEGORIZED",
             category=self.groceries, fingerprint="a",
         )
         Transaction.objects.create(
             account=self.account, posted_on=date(2026, 4, 11),
-            amount=Decimal("-250.00"), description_raw="NOT YET CATEGORISED",
+            amount=Decimal("-250.00"), description_raw="NOT YET CATEGORIZED",
             category=None, fingerprint="b",
         )
 
@@ -1016,11 +1016,11 @@ class UncategorisedSpendTests(TestCase):
             [350.0],
         )
 
-    def test_uncategorised_spend_gets_its_own_visible_slice(self):
+    def test_uncategorized_spend_gets_its_own_visible_slice(self):
         result = analytics.spend_by_category(date(2026, 4, 1), date(2026, 4, 30))
         pairs = dict(zip(result["labels"], result["values"]))
 
-        self.assertEqual(pairs["Not yet categorised"], 250.0)
+        self.assertEqual(pairs["Not yet categorized"], 250.0)
         self.assertEqual(result["total"], 350.0)
 
     def test_income_and_transfers_are_still_excluded(self):

--- a/finance/tests/test_qfr.py
+++ b/finance/tests/test_qfr.py
@@ -424,7 +424,7 @@ class GenerateQFRTransactionIsolationTests(TransactionTestCase):
 
     TransactionTestCase rather than TestCase: the latter wraps each test in a
     transaction, which would mask exactly the thing being asserted -- the
-    same reasoning as the categoriser's own isolation test.
+    same reasoning as the categorizer's own isolation test.
     """
 
     def test_the_narrator_call_is_outside_any_open_transaction(self):

--- a/finance/views_dashboards.py
+++ b/finance/views_dashboards.py
@@ -328,7 +328,7 @@ class ChartsView(FinanceView):
         }
 
     def _income_context(self, start, end, grain, account_ids):
-        # The primary figure: every income-categorised deposit, whether or
+        # The primary figure: every income-categorized deposit, whether or
         # not a payslip was ever imported for it. Works for a household
         # member whose pay never gets a detailed payslip.
         net_income = analytics.net_income_over_time(


### PR DESCRIPTION
## Summary

The app mixed "categorize"/"categorise" freely — most notably, `services/categorize.py` defined a function called `categorise_transactions`, the Spend dashboard's uncategorized-slice label read "Not yet categorised", the LLM system prompt sent to OpenAI and management command help text used the British form, etc.

Renamed every occurrence to the American spelling:
- Function/class names: `categorize_transactions`, `CategorizationSummary`, `_assign_uncategorized`
- The `FINANCE_CATEGORIZER_MODEL` setting/env var — confirmed **unset** in Heroku config, so this is safe with no coordinated deploy step needed (it was already falling back to its code default)
- All docstrings and comments
- User-facing strings: the dashboard category label, the scheduled-report email text
- `RUNBOOK.md`

**Left untouched, deliberately:**
- The `categorize_transactions` management command name/file (already American spelling, and referenced by exact string from `finance_hourly.py`/`finance_daily.py`)
- `UNCATEGORIZED_SLUG` database value (already American spelling)

## Test plan

- [x] `manage.py test finance` — 530 tests, all passing
- [x] `manage.py makemigrations --check --dry-run` — no changes detected
- [x] `manage.py check` — no issues
- [x] Grepped the whole repo for any remaining `categoris`/`Categoris`/`CATEGORIS` — none found

🤖 Generated with [Claude Code](https://claude.com/claude-code)