### PR TITLE
Add a rule-creation UI exposing the full pattern-matching system

### DIFF
--- a/finance/templates/finance/help.html
+++ b/finance/templates/finance/help.html
@@ -24,8 +24,11 @@
     <p class="mt-1.5 text-sm text-text-secondary">
       Every transaction, filterable by account, category, date, or search.
       A category badged "unsure" is the classifier's best guess at a low
-      confidence — confirming it teaches the app for next time, and ticking
-      "always" turns that into a standing rule.
+      confidence — confirming it teaches the app for next time, so the same
+      merchant is never asked about twice. For a standing rule (matching
+      more than one merchant, or beyond an exact match), add it directly
+      from
+      <a href="{% url 'finance:rules' %}" class="text-primary hover:underline">Settings &rarr; Category rules</a>.
     </p>
   </section>
 
@@ -67,8 +70,8 @@
     <h2 class="font-semibold">Settings</h2>
     <p class="mt-1.5 text-sm text-text-secondary">
       Connect an institution, manage existing connections, correct an
-      account's type, and see recent sync history. Category rules created
-      from the review queue live here too.
+      account's type, and see recent sync history. Category rules — contains,
+      starts-with, exact, or regex matching — live here too.
     </p>
   </section>
 

--- a/finance/templates/finance/settings/rule_form.html
+++ b/finance/templates/finance/settings/rule_form.html
@@ -1,0 +1,31 @@
+{% extends "finance/base_finance.html" %}
+
+{% block finance_content %}
+<h1 class="text-2xl font-extrabold tracking-tight md:text-3xl">{{ page_title }}</h1>
+<p class="mt-2 max-w-lg text-text-secondary">
+  Rules run before the classifier and always win, so use them for anything
+  you want categorized the same way every time — an exact match is unlikely
+  for most bank descriptions, so "Contains" is usually the right choice.
+</p>
+
+{% include "finance/partials/messages.html" %}
+
+<form method="post" class="mt-8 max-w-lg space-y-5">
+  {% csrf_token %}
+
+  {% for field in form %}
+    <div>
+      <label for="{{ field.id_for_label }}" class="mb-1.5 block text-sm font-medium">{{ field.label }}</label>
+      {{ field }}
+      {% if field.help_text %}<p class="mt-1.5 text-xs text-text-muted">{{ field.help_text }}</p>{% endif %}
+      {% if field.errors %}<p class="mt-1.5 text-sm text-error">{{ field.errors.0 }}</p>{% endif %}
+    </div>
+  {% endfor %}
+
+  <div class="flex flex-col gap-3 sm:flex-row">
+    <button type="submit" class="rounded-button bg-primary px-6 py-3 font-medium text-white transition hover:bg-primary-600">Save</button>
+    <a href="{% url 'finance:rules' %}"
+       class="rounded-button border border-border px-6 py-3 text-center font-medium text-text-secondary transition hover:bg-muted">Cancel</a>
+  </div>
+</form>
+{% endblock %}

--- a/finance/templates/finance/settings/rules.html
+++ b/finance/templates/finance/settings/rules.html
@@ -9,11 +9,9 @@
   </a>
 </div>
 <p class="mt-2 max-w-2xl text-text-secondary">
-  Rules run before the classifier and always win. Ticking “always” when you
-  confirm a category in the review queue creates a simple "contains" rule on
-  the merchant name — for anything more specific (an exact match, a starting
-  fragment, a regular expression, or one scoped to an account or amount
-  range), add it here directly.
+  Rules run before the classifier and always win — a merchant matching one
+  never reaches review at all. Contains, starts-with, exact, or a regular
+  expression, optionally scoped to one account or an amount range.
 </p>
 
 {% include "finance/partials/messages.html" %}

--- a/finance/templates/finance/settings/rules.html
+++ b/finance/templates/finance/settings/rules.html
@@ -1,10 +1,19 @@
 {% extends "finance/base_finance.html" %}
 
 {% block finance_content %}
-<h1 class="text-2xl font-extrabold tracking-tight md:text-3xl">Category rules</h1>
+<div class="flex flex-wrap items-center justify-between gap-3">
+  <h1 class="text-2xl font-extrabold tracking-tight md:text-3xl">Category rules</h1>
+  <a href="{% url 'finance:rule_create' %}"
+     class="rounded-button bg-primary px-3.5 py-2 text-xs font-medium text-white transition hover:bg-primary-600">
+    Add rule
+  </a>
+</div>
 <p class="mt-2 max-w-2xl text-text-secondary">
-  Rules run before the classifier and always win. Add them from the review queue
-  by ticking “always” when you confirm a category.
+  Rules run before the classifier and always win. Ticking “always” when you
+  confirm a category in the review queue creates a simple "contains" rule on
+  the merchant name — for anything more specific (an exact match, a starting
+  fragment, a regular expression, or one scoped to an account or amount
+  range), add it here directly.
 </p>
 
 {% include "finance/partials/messages.html" %}

--- a/finance/tests/test_settings.py
+++ b/finance/tests/test_settings.py
@@ -24,6 +24,7 @@ from finance.models import (
     Category,
     CategoryRule,
     ConnectionStatus,
+    MatchType,
     UserPreference,
 )
 from finance.providers.base import ProviderError
@@ -438,6 +439,108 @@ class RuleManagementTests(SettingsTestCase):
         self.client.post(reverse("finance:rules"), {"rule": self.rule.pk, "action": "delete"})
 
         self.assertFalse(CategoryRule.objects.filter(pk=self.rule.pk).exists())
+
+
+class RuleCreationTests(SettingsTestCase):
+    """The pattern-matching system the "always" checkbox only ever exposes a
+    sliver of — contains/starts-with/exact/regex, optionally scoped to one
+    account or an amount range, all creatable directly."""
+
+    def setUp(self):
+        super().setUp()
+        self.groceries = Category.objects.get(slug="food-groceries")
+
+    def rule_payload(self, **overrides):
+        payload = {
+            "pattern": "netflix",
+            "match_type": MatchType.CONTAINS,
+            "category": self.groceries.pk,
+            "account": "",
+            "min_amount": "",
+            "max_amount": "",
+            "priority": 100,
+            "notes": "",
+        }
+        payload.update(overrides)
+        return payload
+
+    def test_creating_a_contains_rule(self):
+        response = self.client.post(reverse("finance:rule_create"), self.rule_payload())
+
+        self.assertRedirects(response, reverse("finance:rules"))
+        rule = CategoryRule.objects.get(pattern="netflix")
+        self.assertEqual(rule.match_type, MatchType.CONTAINS)
+        self.assertEqual(rule.category, self.groceries)
+
+    def test_an_exact_match_rule_only_matches_exactly(self):
+        self.client.post(
+            reverse("finance:rule_create"),
+            self.rule_payload(pattern="acme corp", match_type=MatchType.EXACT),
+        )
+
+        rule = CategoryRule.objects.get(pattern="acme corp")
+        self.assertTrue(rule.matches(description="Acme Corp", amount=Decimal("-10")))
+        self.assertFalse(
+            rule.matches(description="Acme Corp #1234 Chicago IL", amount=Decimal("-10"))
+        )
+
+    def test_a_starts_with_rule(self):
+        self.client.post(
+            reverse("finance:rule_create"),
+            self.rule_payload(pattern="sq *", match_type=MatchType.STARTS_WITH),
+        )
+
+        rule = CategoryRule.objects.get(pattern="sq *")
+        self.assertTrue(
+            rule.matches(description="SQ *BLUE BOTTLE COFFEE", amount=Decimal("-5"))
+        )
+        self.assertFalse(rule.matches(description="BLUE BOTTLE SQ *", amount=Decimal("-5")))
+
+    def test_an_invalid_regex_is_rejected_without_saving(self):
+        response = self.client.post(
+            reverse("finance:rule_create"),
+            self.rule_payload(pattern="[unclosed", match_type=MatchType.REGEX),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(CategoryRule.objects.filter(pattern="[unclosed").exists())
+
+    def test_a_rule_can_be_scoped_to_one_account_and_an_amount_range(self):
+        card = make_account(
+            self.institution, name="Card", account_type=AccountType.CREDIT_CARD
+        )
+
+        self.client.post(
+            reverse("finance:rule_create"),
+            self.rule_payload(
+                pattern="amazon", account=card.pk, min_amount="-100", max_amount="-1"
+            ),
+        )
+
+        rule = CategoryRule.objects.get(pattern="amazon")
+        self.assertEqual(rule.account, card)
+        self.assertTrue(
+            rule.matches(description="AMAZON", amount=Decimal("-50"), account_id=card.pk)
+        )
+        self.assertFalse(
+            rule.matches(description="AMAZON", amount=Decimal("-50"), account_id=self.account.pk)
+        )
+
+    def test_a_lower_bound_above_the_upper_bound_is_rejected(self):
+        response = self.client.post(
+            reverse("finance:rule_create"),
+            self.rule_payload(min_amount="10", max_amount="1"),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(CategoryRule.objects.filter(pattern="netflix").exists())
+
+    def test_rule_creation_is_gated_like_everything_else(self):
+        self.client.logout()
+
+        response = self.client.get(reverse("finance:rule_create"))
+
+        self.assertEqual(response.status_code, 403)
 
 
 class PreferenceTests(SettingsTestCase):

--- a/finance/urls.py
+++ b/finance/urls.py
@@ -30,6 +30,7 @@ urlpatterns = [
     path("settings/accounts/new/", views_settings.AccountCreateView.as_view(), name="account_create"),
     path("settings/accounts/<int:pk>/", views_settings.AccountUpdateView.as_view(), name="account_edit"),
     path("settings/rules/", views_settings.RuleListView.as_view(), name="rules"),
+    path("settings/rules/new/", views_settings.RuleCreateView.as_view(), name="rule_create"),
     path("preferences/", views_settings.PreferencesView.as_view(), name="preferences"),
     path("help/", views_help.HelpView.as_view(), name="help"),
     # Alerts and reports

--- a/finance/views_settings.py
+++ b/finance/views_settings.py
@@ -22,6 +22,7 @@ from .models import (
     AccountConnection,
     BalanceSource,
     Budget,
+    Category,
     CategoryRule,
     ConnectionStatus,
     Institution,
@@ -510,6 +511,71 @@ class RuleListView(FinanceAccessMixin, ListView):
             rule.save(update_fields=["is_active", "updated_at"])
 
         return redirect("finance:rules")
+
+
+class RuleForm(forms.ModelForm):
+    """A CategoryRule, editable from Settings rather than only ever created
+    sight-unseen via the review queue's "always" checkbox (which only ever
+    writes a CONTAINS match on the merchant name). The model already
+    supports contains/starts-with/exact/regex matching, optionally scoped
+    to one account or an amount range — this just exposes it."""
+
+    class Meta:
+        model = CategoryRule
+        fields = [
+            "pattern", "match_type", "category", "account",
+            "min_amount", "max_amount", "priority", "notes",
+        ]
+        widgets = {
+            "pattern": forms.TextInput(attrs={"class": FIELD_CLASSES, "placeholder": "netflix"}),
+            "match_type": forms.Select(attrs={"class": FIELD_CLASSES}),
+            "category": forms.Select(attrs={"class": FIELD_CLASSES}),
+            "account": forms.Select(attrs={"class": FIELD_CLASSES}),
+            "min_amount": forms.NumberInput(attrs={"class": FIELD_CLASSES, "step": "0.01"}),
+            "max_amount": forms.NumberInput(attrs={"class": FIELD_CLASSES, "step": "0.01"}),
+            "priority": forms.NumberInput(attrs={"class": FIELD_CLASSES}),
+            "notes": forms.TextInput(attrs={"class": FIELD_CLASSES}),
+        }
+        help_texts = {
+            "pattern": "Matched against the transaction's raw description, case-insensitively.",
+            "match_type": "“Contains” is the most forgiving choice when an exact match is unlikely.",
+            "account": "Leave unset to apply everywhere.",
+            "min_amount": "Signed, inclusive lower bound. Leave blank for no lower bound.",
+            "max_amount": "Signed, inclusive upper bound. Leave blank for no upper bound.",
+            "priority": "Lower runs first. The first matching rule wins.",
+        }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["category"].queryset = Category.objects.filter(
+            is_active=True, children__isnull=True
+        ).select_related("parent").alphabetical()
+        self.fields["account"].queryset = Account.objects.filter(is_active=True)
+        self.fields["account"].required = False
+        self.fields["account"].empty_label = "Every account"
+        self.fields["min_amount"].required = False
+        self.fields["max_amount"].required = False
+        self.fields["notes"].required = False
+
+
+class RuleCreateView(FinanceAccessMixin, CreateView):
+    template_name = "finance/settings/rule_form.html"
+    form_class = RuleForm
+    success_url = reverse_lazy("finance:rules")
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["page_title"] = "New category rule"
+        return context
+
+    def form_valid(self, form):
+        rule = form.instance
+        messages.success(
+            self.request,
+            f"Anything that {rule.get_match_type_display().lower()} "
+            f"“{rule.pattern}” now goes to {rule.category}.",
+        )
+        return super().form_valid(form)
 
 
 class PreferencesForm(forms.ModelForm):


### PR DESCRIPTION
## Summary

`CategoryRule` already supported `contains`/`starts_with`/`exact`/`regex` matching, plus optional account and amount-range scoping — but the only way to create one was the review queue's "always" checkbox, which always creates a `contains` match on the normalized merchant name with no way to pick anything else.

Settings → Category rules now has an "Add rule" button and a form exposing every field the model already had: pattern, match type, category, account, min/max amount, priority, notes. Model-level validation (invalid regex, a lower bound above the upper bound) surfaces as ordinary form errors via `CategoryRule.clean()`, which `ModelForm` already calls through `full_clean()`.

The review queue's "always" checkbox is unchanged — still the fast path for the common case (contains-match on the merchant), with this as the place to reach for anything more specific.

## Test plan

- [x] `manage.py test finance` — 537 tests, all passing (new: creating each match type and confirming `rule.matches()` behaves as expected — exact vs. contains vs. starts-with; account + amount-range scoping actually narrows matches; invalid regex and inverted min/max bounds are rejected without saving; gated behind auth)
- [x] `manage.py makemigrations --check --dry-run` — no changes detected (no model changes — only exposing existing fields)
- [x] `manage.py check` — no issues
- [x] `npm run tailwind:build` — no new classes needed
- [x] Verified locally in browser: created a real "starts with" rule end-to-end, saw the success message and the new rule listed correctly, then deleted it

🤖 Generated with [Claude Code](https://claude.com/claude-code)