### PR TITLE
Fix classifier's OpenAI call: json_object mode needs literal "json" in prompt

### DIFF
--- a/finance/services/classifier.py
+++ b/finance/services/classifier.py
@@ -35,7 +35,9 @@ Rules:
   confidence. When you have no real idea, use "uncategorized" with a low
   confidence rather than guessing something plausible-sounding.
 - confidence is 0.0 to 1.0 and should reflect real uncertainty. A well-known
-  national merchant is high confidence; an ambiguous abbreviation is not."""
+  national merchant is high confidence; an ambiguous abbreviation is not.
+
+Respond with a single JSON object matching the given response_shape."""
 
 
 @dataclass(frozen=True)

--- a/finance/tests/test_categorize.py
+++ b/finance/tests/test_categorize.py
@@ -226,6 +226,14 @@ class ClassifierTests(PipelineTestCase):
 
         self.assertEqual(parsed, [])
 
+    def test_the_system_prompt_says_json_as_required_by_response_format(self):
+        # OpenAI's API rejects response_format=json_object unless one of the
+        # messages literally contains the word "json" — a 400 that silently
+        # failed every batch in production until this was added.
+        from finance.services.classifier import SYSTEM_PROMPT
+
+        self.assertIn("json", SYSTEM_PROMPT.lower())
+
     def test_without_an_api_key_the_deterministic_steps_still_work(self):
         from finance.services.classifier import NullClassifier
 


### PR DESCRIPTION
## Summary
- The production `categorize_transactions --recategorize` run just failed every classifier batch with an OpenAI 400 (`response_format=json_object` requires the word "json" literally in a message) — all 4,143 transactions landed in the review queue as "unmatched" instead of being classified.
- Added "Respond with a single JSON object matching the given response_shape." to `SYSTEM_PROMPT`.
- Added a regression test asserting "json" appears in the prompt — none of the existing classifier tests caught this since they all go through `StubClassifier`, never `OpenAIClassifier`'s real request.

## Test plan
- [x] `manage.py test finance` — 554 passing
- [x] `makemigrations --check --dry-run` — no changes
- [x] `manage.py check` — clean