### PR TITLE
Fix Save button stuck disabled on review rows; tighten classifier prompt

### DIFF
--- a/finance/services/classifier.py
+++ b/finance/services/classifier.py
@@ -28,7 +28,12 @@ You will get a list of merchant descriptions and a list of allowed categories.
 Assign each merchant exactly one category slug from the list.
 
 Rules:
-- Use only slugs from the provided list. Never invent one.
+- Copy the "slug" value character-for-character from the provided category
+  list. Never construct one yourself from a category's name or from what
+  seems like a plausible pattern — a slug that isn't an exact, verbatim match
+  for one in the list is treated as invalid and discarded.
+- If nothing in the list is a good fit, use "uncategorized" exactly as given
+  rather than inventing a slug that isn't there.
 - Judge by the merchant, not the amount.
 - Prefer the most specific category that clearly fits.
 - When genuinely unsure between categories, pick the closest and lower your

--- a/finance/templates/finance/transactions/list.html
+++ b/finance/templates/finance/transactions/list.html
@@ -130,7 +130,7 @@
       </div>
 
       <form method="post" class="mt-3 flex flex-wrap items-center gap-2"
-            x-data="{ initial: '{{ txn.category_id|default:'' }}', selected: '{{ txn.category_id|default:'' }}' }">
+            x-data="{ initial: '{{ txn.category_id|default:'' }}', selected: '{{ txn.category_id|default:'' }}', needsReview: {{ txn.needs_review|yesno:'true,false' }} }">
         {% csrf_token %}
         <input type="hidden" name="transaction" value="{{ txn.pk }}" />
         <input type="hidden" name="next" value="{{ request.get_full_path }}" />
@@ -142,7 +142,7 @@
           {% endfor %}
         </select>
 
-        <button type="submit" :disabled="selected === initial"
+        <button type="submit" :disabled="selected === initial && !needsReview"
                 class="rounded-button bg-primary px-3 py-1.5 text-xs font-medium text-white transition hover:bg-primary-600 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-primary">
           Save
         </button>

--- a/finance/tests/test_categorize.py
+++ b/finance/tests/test_categorize.py
@@ -234,6 +234,16 @@ class ClassifierTests(PipelineTestCase):
 
         self.assertIn("json", SYSTEM_PROMPT.lower())
 
+    def test_the_system_prompt_insists_on_a_verbatim_slug_copy(self):
+        # A production run classified real merchants and the model invented
+        # plausible-but-nonexistent slugs (e.g. "transport-auto-maintenance"
+        # instead of "transport-maintenance") often enough to be worth
+        # explicitly warning against, even though _parse's allowed-slug guard
+        # already discards anything that doesn't match.
+        from finance.services.classifier import SYSTEM_PROMPT
+
+        self.assertIn("character-for-character", SYSTEM_PROMPT)
+
     def test_without_an_api_key_the_deterministic_steps_still_work(self):
         from finance.services.classifier import NullClassifier
 

--- a/finance/tests/test_ux_polish.py
+++ b/finance/tests/test_ux_polish.py
@@ -112,9 +112,10 @@ class ReviewQueueSaveButtonTests(TestCase):
         # expression evaluates true (nothing changed) until the person
         # actually picks something else.
         self.assertIn(
-            f"initial: '{self.groceries.pk}', selected: '{self.groceries.pk}'", body
+            f"initial: '{self.groceries.pk}', selected: '{self.groceries.pk}', needsReview: false",
+            body,
         )
-        self.assertIn(':disabled="selected === initial"', body)
+        self.assertIn(':disabled="selected === initial && !needsReview"', body)
 
     def test_picking_a_different_category_is_the_only_way_to_enable_it(self):
         # No "always"/create-a-rule shortcut folded into this save anymore —
@@ -131,6 +132,26 @@ class ReviewQueueSaveButtonTests(TestCase):
 
         self.assertNotContains(response, 'name="create_rule"')
         self.assertNotContains(response, ">always<")
+
+    def test_a_row_needing_review_can_be_saved_without_changing_the_category(self):
+        # The classifier's suggestion prefills the select, so a row that
+        # merely needs confirming starts with selected === initial — the
+        # Save button must still be enabled so "approve as suggested" is
+        # possible without picking a different category first.
+        make_transaction(
+            self.checking,
+            description_raw="MARIANOS",
+            category=self.groceries,
+            needs_review=True,
+        )
+
+        response = self.client.get(reverse("finance:transactions"))
+        body = response.content.decode()
+
+        self.assertIn(
+            f"initial: '{self.groceries.pk}', selected: '{self.groceries.pk}', needsReview: true",
+            body,
+        )
 
 
 class InstitutionManagementTests(TestCase):


### PR DESCRIPTION
## Summary
- **Bug**: on the Activity/review-queue page, a transaction needing review has its category `<select>` prefilled with the classifier's own suggestion, so `selected === initial` from the start — the Save button (disabled when nothing's "changed") could never be clicked to approve a suggestion as-is. Fixed by also enabling Save whenever the row `needs_review`.
- **Prompt tightening**: the production recategorize run showed the classifier occasionally inventing plausible-but-nonexistent slugs (e.g. `transport-auto-maintenance` instead of `transport-maintenance`). The existing guard already discards these safely, but it meant needless extra review items. Strengthened the system prompt to require a verbatim, character-for-character slug copy from the provided list.

## Test plan
- [x] `manage.py test finance` — 556 passing, including a new regression test for the review-row Save-enabled case and a prompt-content assertion
- [x] `makemigrations --check --dry-run` — no changes
- [x] `manage.py check` — clean
- [x] `npm run tailwind:build` — no diff