### PR TITLE
Add category management: create, edit, archive, delete

### DIFF
--- a/finance/templates/finance/help.html
+++ b/finance/templates/finance/help.html
@@ -71,7 +71,11 @@
     <p class="mt-1.5 text-sm text-text-secondary">
       Connect an institution, manage existing connections, correct an
       account's type, and see recent sync history. Category rules — contains,
-      starts-with, exact, or regex matching — live here too.
+      starts-with, exact, or regex matching — live here too, alongside the
+      category list itself: create, rename, or archive one (it stays
+      selectable, just tucked into its own section at the bottom of the
+      picker) — or delete it outright, which asks where its existing
+      transactions should go first.
     </p>
   </section>
 

--- a/finance/templates/finance/settings/categories.html
+++ b/finance/templates/finance/settings/categories.html
@@ -1,0 +1,68 @@
+{% extends "finance/base_finance.html" %}
+
+{% block finance_content %}
+<div class="flex flex-wrap items-center justify-between gap-3">
+  <h1 class="text-2xl font-extrabold tracking-tight md:text-3xl">Categories</h1>
+  <a href="{% url 'finance:category_create' %}"
+     class="rounded-button bg-primary px-3.5 py-2 text-xs font-medium text-white transition hover:bg-primary-600">
+    Add category
+  </a>
+</div>
+<p class="mt-2 max-w-2xl text-text-secondary">
+  Archiving keeps a category selectable on existing transactions — it just
+  moves to its own section at the bottom of the category picker, so old data
+  stays readable without cluttering the choices for new ones. Deleting asks
+  where its transactions should go instead of leaving them uncategorized by
+  accident.
+</p>
+
+{% include "finance/partials/messages.html" %}
+
+<div class="mt-8 space-y-2">
+  {% for category in categories %}
+    <div class="rounded-card border border-border bg-surface p-4 {% if not category.is_active %}opacity-60{% endif %}">
+      <div class="flex flex-wrap items-center justify-between gap-3">
+        <div class="min-w-0">
+          <p class="truncate text-sm font-medium">
+            {{ category.full_path }}
+            {% if not category.is_active %}
+              <span class="ml-1 rounded-full bg-muted px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-text-muted">Archived</span>
+            {% endif %}
+            {% if category.is_system %}
+              <span class="ml-1 rounded-full bg-muted px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-text-muted">System</span>
+            {% endif %}
+          </p>
+          <p class="mt-1 text-xs text-text-muted">
+            {{ category.get_kind_display }} · {{ category.transaction_count }} transaction{{ category.transaction_count|pluralize }}
+          </p>
+        </div>
+
+        <div class="flex shrink-0 flex-wrap gap-2">
+          <a href="{% url 'finance:category_edit' category.pk %}"
+             class="rounded-button border border-border px-3 py-1.5 text-xs transition hover:bg-muted">
+            Edit
+          </a>
+          {% if not category.is_system %}
+            <form method="post" action="{% url 'finance:categories' %}">
+              {% csrf_token %}
+              <input type="hidden" name="category" value="{{ category.pk }}" />
+              <button type="submit"
+                      class="rounded-button border border-border px-3 py-1.5 text-xs transition hover:bg-muted">
+                {% if category.is_active %}Archive{% else %}Unarchive{% endif %}
+              </button>
+            </form>
+            <a href="{% url 'finance:category_delete' category.pk %}"
+               class="rounded-button px-3 py-1.5 text-xs text-error transition hover:bg-error/10">
+              Delete
+            </a>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+  {% empty %}
+    <div class="rounded-card border border-dashed border-border bg-surface/50 p-8 text-center">
+      <p class="text-text-secondary">No categories yet.</p>
+    </div>
+  {% endfor %}
+</div>
+{% endblock %}

--- a/finance/templates/finance/settings/category_delete.html
+++ b/finance/templates/finance/settings/category_delete.html
@@ -1,0 +1,52 @@
+{% extends "finance/base_finance.html" %}
+
+{% block finance_content %}
+<h1 class="text-2xl font-extrabold tracking-tight md:text-3xl">Delete {{ category.full_path }}</h1>
+
+{% include "finance/partials/messages.html" %}
+
+<div class="mt-6 max-w-lg space-y-3 rounded-card border border-warning/40 bg-warning/5 p-5 text-sm">
+  <p>
+    This permanently removes <span class="font-medium">{{ category.full_path }}</span>.
+    {% if transaction_count %}
+      {{ transaction_count }} transaction{{ transaction_count|pluralize }} currently filed
+      here will be moved to whatever you pick below first.
+    {% else %}
+      No transactions are currently filed here.
+    {% endif %}
+  </p>
+  {% if rule_count %}
+    <p>{{ rule_count }} category rule{{ rule_count|pluralize }} pointing here will be deleted too.</p>
+  {% endif %}
+  {% if memo_count %}
+    <p>
+      {{ memo_count }} remembered merchant{{ memo_count|pluralize }} will be forgotten —
+      those merchants go back through the classifier the next time they show up.
+    </p>
+  {% endif %}
+</div>
+
+<form method="post" class="mt-6 max-w-lg space-y-5">
+  {% csrf_token %}
+
+  <div>
+    <label for="reassign_to" class="mb-1.5 block text-sm font-medium">Move existing transactions to</label>
+    <select name="reassign_to" id="reassign_to"
+            class="w-full rounded-button border border-border bg-background px-3 py-2 text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-primary">
+      {% for choice in reassign_choices %}
+        <option value="{{ choice.pk }}" {% if choice.pk == default_reassign.pk %}selected{% endif %}>{{ choice.full_path }}</option>
+      {% endfor %}
+    </select>
+  </div>
+
+  <div class="flex flex-col gap-3 sm:flex-row">
+    <button type="submit" class="rounded-button bg-error px-6 py-3 font-medium text-white transition hover:bg-error/90">
+      Delete category
+    </button>
+    <a href="{% url 'finance:categories' %}"
+       class="rounded-button border border-border px-6 py-3 text-center font-medium text-text-secondary transition hover:bg-muted">
+      Cancel
+    </a>
+  </div>
+</form>
+{% endblock %}

--- a/finance/templates/finance/settings/category_form.html
+++ b/finance/templates/finance/settings/category_form.html
@@ -1,0 +1,26 @@
+{% extends "finance/base_finance.html" %}
+
+{% block finance_content %}
+<h1 class="text-2xl font-extrabold tracking-tight md:text-3xl">{{ page_title }}</h1>
+
+{% include "finance/partials/messages.html" %}
+
+<form method="post" class="mt-8 max-w-lg space-y-5">
+  {% csrf_token %}
+
+  {% for field in form %}
+    <div>
+      <label for="{{ field.id_for_label }}" class="mb-1.5 block text-sm font-medium">{{ field.label }}</label>
+      {{ field }}
+      {% if field.help_text %}<p class="mt-1.5 text-xs text-text-muted">{{ field.help_text }}</p>{% endif %}
+      {% if field.errors %}<p class="mt-1.5 text-sm text-error">{{ field.errors.0 }}</p>{% endif %}
+    </div>
+  {% endfor %}
+
+  <div class="flex flex-col gap-3 sm:flex-row">
+    <button type="submit" class="rounded-button bg-primary px-6 py-3 font-medium text-white transition hover:bg-primary-600">Save</button>
+    <a href="{% url 'finance:categories' %}"
+       class="rounded-button border border-border px-6 py-3 text-center font-medium text-text-secondary transition hover:bg-muted">Cancel</a>
+  </div>
+</form>
+{% endblock %}

--- a/finance/templates/finance/settings/index.html
+++ b/finance/templates/finance/settings/index.html
@@ -96,7 +96,7 @@
   </ul>
 </section>
 
-<section class="mt-8 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+<section class="mt-8 grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
   <a href="{% url 'finance:institutions' %}" class="rounded-card border border-border bg-surface p-4 transition hover:border-primary/50">
     <p class="text-sm font-medium">Institutions</p>
     <p class="mt-1 text-xs text-text-muted">{{ institution_count }} on file</p>
@@ -108,6 +108,10 @@
   <a href="{% url 'finance:rules' %}" class="rounded-card border border-border bg-surface p-4 transition hover:border-primary/50">
     <p class="text-sm font-medium">Category rules</p>
     <p class="mt-1 text-xs text-text-muted">{{ rule_count }} configured</p>
+  </a>
+  <a href="{% url 'finance:categories' %}" class="rounded-card border border-border bg-surface p-4 transition hover:border-primary/50">
+    <p class="text-sm font-medium">Categories</p>
+    <p class="mt-1 text-xs text-text-muted">{{ category_count }} defined</p>
   </a>
   <a href="{% url 'finance:imports' %}" class="rounded-card border border-border bg-surface p-4 transition hover:border-primary/50">
     <p class="text-sm font-medium">Imports</p>

--- a/finance/templates/finance/transactions/list.html
+++ b/finance/templates/finance/transactions/list.html
@@ -140,6 +140,13 @@
           {% for category in categories %}
             <option value="{{ category.pk }}" {% if txn.category_id == category.pk %}selected{% endif %}>{{ category.full_path }}</option>
           {% endfor %}
+          {% if archived_categories %}
+            <optgroup label="Archived" class="text-text-muted">
+              {% for category in archived_categories %}
+                <option value="{{ category.pk }}" class="text-text-muted" {% if txn.category_id == category.pk %}selected{% endif %}>{{ category.full_path }}</option>
+              {% endfor %}
+            </optgroup>
+          {% endif %}
         </select>
 
         <button type="submit" :disabled="selected === initial && !needsReview"

--- a/finance/tests/test_settings.py
+++ b/finance/tests/test_settings.py
@@ -14,6 +14,7 @@ from django.test import TestCase
 from django.urls import reverse
 from django_otp.plugins.otp_totp.models import TOTPDevice
 
+from finance.categories_seed import UNCATEGORIZED_SLUG
 from finance.models import (
     Account,
     AccountBalanceSnapshot,
@@ -22,9 +23,12 @@ from finance.models import (
     BalanceSource,
     Budget,
     Category,
+    CategoryKind,
     CategoryRule,
+    CategorySource,
     ConnectionStatus,
     MatchType,
+    MerchantCategoryMemo,
     UserPreference,
 )
 from finance.providers.base import ProviderError
@@ -203,6 +207,186 @@ class CategorizeNowTests(SettingsTestCase):
         self.client.logout()
 
         response = self.client.post(reverse("finance:settings"), {"action": "categorize"})
+
+        self.assertEqual(response.status_code, 403)
+
+
+class CategoryManagementTests(SettingsTestCase):
+    """Create, rename, archive, and delete a household category — separate
+    from CategoryRule, which only maps descriptions to an existing one."""
+
+    def setUp(self):
+        super().setUp()
+        self.groceries = Category.objects.get(slug="food-groceries")
+        self.uncategorized = Category.objects.get(slug=UNCATEGORIZED_SLUG)
+
+    def test_creating_a_top_level_category(self):
+        response = self.client.post(
+            reverse("finance:category_create"),
+            {"name": "Crypto", "parent": "", "kind": CategoryKind.EXPENSE, "sort_order": 100, "description": ""},
+        )
+
+        self.assertRedirects(response, reverse("finance:categories"))
+        category = Category.objects.get(name="Crypto")
+        self.assertEqual(category.slug, "crypto")
+        self.assertIsNone(category.parent)
+
+    def test_creating_a_subcategory_under_a_parent(self):
+        parent = Category.objects.get(slug="food")
+
+        response = self.client.post(
+            reverse("finance:category_create"),
+            {"name": "Meal Kits", "parent": parent.pk, "kind": CategoryKind.EXPENSE, "sort_order": 100, "description": ""},
+        )
+
+        self.assertRedirects(response, reverse("finance:categories"))
+        category = Category.objects.get(name="Meal Kits")
+        self.assertEqual(category.parent, parent)
+
+    def test_a_mismatched_kind_against_the_parent_is_rejected(self):
+        parent = Category.objects.get(slug="food")
+
+        response = self.client.post(
+            reverse("finance:category_create"),
+            {"name": "Meal Kits", "parent": parent.pk, "kind": CategoryKind.INCOME, "sort_order": 100, "description": ""},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(Category.objects.filter(name="Meal Kits").exists())
+
+    def test_renaming_a_category_does_not_change_its_slug(self):
+        response = self.client.post(
+            reverse("finance:category_edit", args=[self.groceries.pk]),
+            {
+                "name": "Grocery Shopping",
+                "parent": self.groceries.parent_id or "",
+                "kind": self.groceries.kind,
+                "sort_order": self.groceries.sort_order,
+                "description": "",
+            },
+        )
+
+        self.assertRedirects(response, reverse("finance:categories"))
+        self.groceries.refresh_from_db()
+        self.assertEqual(self.groceries.name, "Grocery Shopping")
+        self.assertEqual(self.groceries.slug, "food-groceries")
+
+    def test_a_category_cannot_be_nested_under_its_own_descendant(self):
+        parent = Category.objects.get(slug="food")
+
+        response = self.client.post(
+            reverse("finance:category_edit", args=[parent.pk]),
+            {
+                "name": parent.name,
+                "parent": self.groceries.pk,
+                "kind": parent.kind,
+                "sort_order": parent.sort_order,
+                "description": "",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        parent.refresh_from_db()
+        self.assertIsNone(parent.parent)
+
+    def test_archiving_a_category_flips_is_active(self):
+        response = self.client.post(
+            reverse("finance:categories"), {"category": self.groceries.pk}
+        )
+
+        self.assertRedirects(response, reverse("finance:categories"))
+        self.groceries.refresh_from_db()
+        self.assertFalse(self.groceries.is_active)
+
+    def test_archiving_again_unarchives_it(self):
+        self.groceries.is_active = False
+        self.groceries.save(update_fields=["is_active"])
+
+        self.client.post(reverse("finance:categories"), {"category": self.groceries.pk})
+
+        self.groceries.refresh_from_db()
+        self.assertTrue(self.groceries.is_active)
+
+    def test_a_system_category_cannot_be_archived(self):
+        response = self.client.post(
+            reverse("finance:categories"), {"category": self.uncategorized.pk}
+        )
+
+        self.assertRedirects(response, reverse("finance:categories"))
+        self.uncategorized.refresh_from_db()
+        self.assertTrue(self.uncategorized.is_active)
+
+    def test_a_system_category_cannot_be_deleted(self):
+        response = self.client.post(
+            reverse("finance:category_delete", args=[self.uncategorized.pk]),
+            {"reassign_to": self.groceries.pk},
+        )
+
+        self.assertRedirects(response, reverse("finance:categories"))
+        self.assertTrue(Category.objects.filter(pk=self.uncategorized.pk).exists())
+
+    def test_a_category_with_children_cannot_be_deleted_directly(self):
+        parent = Category.objects.get(slug="food")
+
+        response = self.client.post(
+            reverse("finance:category_delete", args=[parent.pk]),
+            {"reassign_to": self.groceries.pk},
+        )
+
+        self.assertRedirects(response, reverse("finance:category_delete", args=[parent.pk]))
+        self.assertTrue(Category.objects.filter(pk=parent.pk).exists())
+
+    def test_deleting_reassigns_its_transactions_to_the_chosen_category(self):
+        restaurants = Category.objects.get(slug="food-restaurants")
+        txn = make_transaction(self.account, category=self.groceries, needs_review=False)
+
+        response = self.client.post(
+            reverse("finance:category_delete", args=[self.groceries.pk]),
+            {"reassign_to": restaurants.pk},
+        )
+
+        self.assertRedirects(response, reverse("finance:categories"))
+        self.assertFalse(Category.objects.filter(pk=self.groceries.pk).exists())
+        txn.refresh_from_db()
+        self.assertEqual(txn.category, restaurants)
+        self.assertEqual(txn.category_source, CategorySource.MANUAL)
+        self.assertFalse(txn.needs_review)
+
+    def test_deleting_to_uncategorized_flags_the_moved_transactions_for_review(self):
+        txn = make_transaction(self.account, category=self.groceries, needs_review=False)
+
+        self.client.post(
+            reverse("finance:category_delete", args=[self.groceries.pk]),
+            {"reassign_to": self.uncategorized.pk},
+        )
+
+        txn.refresh_from_db()
+        self.assertEqual(txn.category, self.uncategorized)
+        self.assertTrue(txn.needs_review)
+
+    def test_deleting_cascades_its_rules_and_memos(self):
+        rule = CategoryRule.objects.create(pattern="marianos", category=self.groceries)
+        memo = MerchantCategoryMemo.objects.create(merchant_key="marianos", category=self.groceries)
+
+        self.client.post(
+            reverse("finance:category_delete", args=[self.groceries.pk]),
+            {"reassign_to": self.uncategorized.pk},
+        )
+
+        self.assertFalse(CategoryRule.objects.filter(pk=rule.pk).exists())
+        self.assertFalse(MerchantCategoryMemo.objects.filter(pk=memo.pk).exists())
+
+    def test_delete_confirmation_defaults_the_reassignment_target_to_uncategorized(self):
+        response = self.client.get(reverse("finance:category_delete", args=[self.groceries.pk]))
+        body = response.content.decode()
+
+        marker = f'value="{self.uncategorized.pk}" selected'
+        self.assertIn(marker, body)
+
+    def test_categories_page_is_gated_like_everything_else(self):
+        self.client.logout()
+
+        response = self.client.get(reverse("finance:categories"))
 
         self.assertEqual(response.status_code, 403)
 

--- a/finance/tests/test_ux_polish.py
+++ b/finance/tests/test_ux_polish.py
@@ -133,6 +133,25 @@ class ReviewQueueSaveButtonTests(TestCase):
         self.assertNotContains(response, 'name="create_rule"')
         self.assertNotContains(response, ">always<")
 
+    def test_an_archived_category_appears_in_its_own_optgroup(self):
+        restaurants = Category.objects.get(slug="food-restaurants")
+        restaurants.is_active = False
+        restaurants.save(update_fields=["is_active"])
+
+        make_transaction(self.checking, description_raw="MARIANOS", category=self.groceries)
+
+        response = self.client.get(reverse("finance:transactions"))
+        body = response.content.decode()
+
+        self.assertIn('<optgroup label="Archived"', body)
+        self.assertIn(f'value="{restaurants.pk}"', body)
+
+    def test_an_active_category_never_appears_in_the_archived_optgroup(self):
+        response = self.client.get(reverse("finance:transactions"))
+        body = response.content.decode()
+
+        self.assertNotIn('<optgroup label="Archived"', body)
+
     def test_a_row_needing_review_can_be_saved_without_changing_the_category(self):
         # The classifier's suggestion prefills the select, so a row that
         # merely needs confirming starts with selected === initial — the

--- a/finance/urls.py
+++ b/finance/urls.py
@@ -31,6 +31,10 @@ urlpatterns = [
     path("settings/accounts/<int:pk>/", views_settings.AccountUpdateView.as_view(), name="account_edit"),
     path("settings/rules/", views_settings.RuleListView.as_view(), name="rules"),
     path("settings/rules/new/", views_settings.RuleCreateView.as_view(), name="rule_create"),
+    path("settings/categories/", views_settings.CategoryListView.as_view(), name="categories"),
+    path("settings/categories/new/", views_settings.CategoryCreateView.as_view(), name="category_create"),
+    path("settings/categories/<int:pk>/", views_settings.CategoryUpdateView.as_view(), name="category_edit"),
+    path("settings/categories/<int:pk>/delete/", views_settings.CategoryDeleteView.as_view(), name="category_delete"),
     path("preferences/", views_settings.PreferencesView.as_view(), name="preferences"),
     path("help/", views_help.HelpView.as_view(), name="help"),
     # Alerts and reports

--- a/finance/views_settings.py
+++ b/finance/views_settings.py
@@ -9,6 +9,8 @@ one person sees that ledger, so they never touch shared data.
 
 from django import forms
 from django.contrib import messages
+from django.db import transaction as db_transaction
+from django.db.models import Count
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse_lazy
 from django.utils import timezone
@@ -16,6 +18,7 @@ from django.utils.text import slugify
 from django.views.generic import CreateView, FormView, ListView, TemplateView, UpdateView
 
 from .access import FinanceAccessMixin
+from .categories_seed import UNCATEGORIZED_SLUG
 from .dates import household_today
 from .models import (
     Account,
@@ -24,6 +27,7 @@ from .models import (
     Budget,
     Category,
     CategoryRule,
+    CategorySource,
     ConnectionStatus,
     Institution,
     Provider,
@@ -65,6 +69,7 @@ class SettingsHomeView(FinanceView):
                 "institution_count": Institution.objects.count(),
                 "budget_count": Budget.objects.count(),
                 "rule_count": CategoryRule.objects.count(),
+                "category_count": Category.objects.count(),
                 "needs_attention": AccountConnection.objects.filter(
                     status__in=[ConnectionStatus.NEEDS_REAUTH, ConnectionStatus.ERROR]
                 ).defer("access_secret"),
@@ -595,6 +600,232 @@ class RuleCreateView(FinanceAccessMixin, CreateView):
             f"“{rule.pattern}” now goes to {rule.category}.",
         )
         return super().form_valid(form)
+
+
+class CategoryForm(forms.ModelForm):
+    """Create or rename a category. The slug is set once, at creation, and
+    never changes after — several system categories (Uncategorized, Internal
+    Transfer, Credit Card Payment) are looked up by slug in code, and a
+    handful of other slugs are what CategoryRule/MerchantCategoryMemo
+    matching keys off of, so renaming a category must not disturb it."""
+
+    class Meta:
+        model = Category
+        fields = ["name", "parent", "kind", "sort_order", "description"]
+        widgets = {
+            "name": forms.TextInput(attrs={"class": FIELD_CLASSES, "placeholder": "Groceries"}),
+            "parent": forms.Select(attrs={"class": FIELD_CLASSES}),
+            "kind": forms.Select(attrs={"class": FIELD_CLASSES}),
+            "sort_order": forms.NumberInput(attrs={"class": FIELD_CLASSES}),
+            "description": forms.TextInput(attrs={"class": FIELD_CLASSES}),
+        }
+        help_texts = {
+            "parent": "Leave unset for a top-level category. Nesting goes at most three levels deep.",
+            "kind": "A subcategory must share its parent's kind.",
+            "sort_order": "Lower sorts first among siblings.",
+            "description": "Steers the classifier — say what belongs here and what doesn't.",
+        }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["parent"].queryset = Category.objects.filter(is_active=True)
+        self.fields["parent"].required = False
+        self.fields["parent"].empty_label = "No parent (top-level)"
+        self.fields["description"].required = False
+
+    def clean_parent(self):
+        parent = self.cleaned_data.get("parent")
+
+        if parent and self.instance.pk:
+            # Without this guard, picking one of a category's own descendants
+            # as its new parent creates a cycle — full_path/depth walk parent
+            # links and would loop forever.
+            node = parent
+            while node is not None:
+                if node.pk == self.instance.pk:
+                    raise forms.ValidationError(
+                        "A category can't be nested under one of its own subcategories."
+                    )
+                node = node.parent
+
+        return parent
+
+    def save(self, commit=True):
+        category = super().save(commit=False)
+
+        if not category.slug:
+            category.slug = self._unique_slug(category.name)
+
+        if commit:
+            category.save()
+
+        return category
+
+    def _unique_slug(self, name):
+        base = slugify(name)[:90] or "category"
+        slug = base
+        suffix = 1
+
+        while Category.objects.filter(slug=slug).exclude(pk=self.instance.pk).exists():
+            suffix += 1
+            slug = f"{base}-{suffix}"
+
+        return slug
+
+
+class CategoryListView(FinanceAccessMixin, ListView):
+    template_name = "finance/settings/categories.html"
+    context_object_name = "categories"
+
+    def get_queryset(self):
+        return (
+            Category.objects.select_related("parent")
+            .annotate(transaction_count=Count("transactions", distinct=True))
+            .alphabetical()
+        )
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["page_title"] = "Categories"
+        return context
+
+    def post(self, request, *args, **kwargs):
+        category = get_object_or_404(Category, pk=request.POST.get("category"))
+
+        if category.is_system:
+            messages.error(request, "This category is built into the app and can't be archived.")
+            return redirect("finance:categories")
+
+        category.is_active = not category.is_active
+        category.save(update_fields=["is_active", "updated_at"])
+
+        messages.info(
+            request,
+            f"{category.full_path} {'archived' if not category.is_active else 'unarchived'}.",
+        )
+        return redirect("finance:categories")
+
+
+class CategoryCreateView(FinanceAccessMixin, CreateView):
+    template_name = "finance/settings/category_form.html"
+    form_class = CategoryForm
+    success_url = reverse_lazy("finance:categories")
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["page_title"] = "New category"
+        return context
+
+    def form_valid(self, form):
+        response = super().form_valid(form)
+        messages.success(self.request, f"Added {self.object.full_path}.")
+        return response
+
+
+class CategoryUpdateView(FinanceAccessMixin, UpdateView):
+    template_name = "finance/settings/category_form.html"
+    form_class = CategoryForm
+    model = Category
+    success_url = reverse_lazy("finance:categories")
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["page_title"] = f"Edit {self.object.full_path}"
+        return context
+
+    def form_valid(self, form):
+        response = super().form_valid(form)
+        messages.success(self.request, f"Updated {self.object.full_path}.")
+        return response
+
+
+class CategoryDeleteView(FinanceAccessMixin, TemplateView):
+    """Deleting a category cascades to its CategoryRules and
+    MerchantCategoryMemos (both FK on_delete=CASCADE), and would otherwise
+    silently null out every transaction currently filed under it
+    (Transaction.category is on_delete=SET_NULL). Reassigning those
+    transactions to a chosen category first — defaulting to Uncategorized —
+    keeps that from happening quietly."""
+
+    template_name = "finance/settings/category_delete.html"
+
+    def get_category(self):
+        return get_object_or_404(Category, pk=self.kwargs["pk"])
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        category = self.get_category()
+        default_reassign = Category.objects.filter(slug=UNCATEGORIZED_SLUG).first()
+
+        context.update(
+            {
+                "page_title": f"Delete {category.full_path}",
+                "category": category,
+                "transaction_count": category.transactions.count(),
+                "rule_count": category.rules.count(),
+                "memo_count": category.merchant_memos.count(),
+                "child_count": category.children.count(),
+                "reassign_choices": Category.objects.filter(is_active=True)
+                .exclude(pk=category.pk)
+                .select_related("parent")
+                .alphabetical(),
+                "default_reassign": default_reassign,
+            }
+        )
+        return context
+
+    def post(self, request, *args, **kwargs):
+        category = self.get_category()
+
+        if category.is_system:
+            messages.error(request, "This category is built into the app and can't be deleted.")
+            return redirect("finance:categories")
+
+        if category.children.exists():
+            messages.error(
+                request,
+                f"{category.full_path} has subcategories — delete or reassign those first.",
+            )
+            return redirect("finance:category_delete", pk=category.pk)
+
+        reassign_to = (
+            Category.objects.filter(pk=request.POST.get("reassign_to"), is_active=True)
+            .exclude(pk=category.pk)
+            .first()
+        )
+
+        if reassign_to is None:
+            messages.error(request, "Pick a category for the existing transactions to move to.")
+            return redirect("finance:category_delete", pk=category.pk)
+
+        with db_transaction.atomic():
+            moved = category.transactions.count()
+
+            if reassign_to.slug == UNCATEGORIZED_SLUG:
+                # Matches services.categorize._assign_uncategorized: parked
+                # for review rather than treated as a confirmed decision.
+                category.transactions.update(
+                    category=reassign_to,
+                    category_source="",
+                    category_confidence=0.0,
+                    needs_review=True,
+                )
+            else:
+                category.transactions.update(
+                    category=reassign_to,
+                    category_source=CategorySource.MANUAL,
+                    category_confidence=1.0,
+                    needs_review=False,
+                )
+
+            name = category.full_path
+            category.delete()
+
+        messages.success(
+            request,
+            f"Deleted {name}. {moved} transaction{'s' if moved != 1 else ''} moved to {reassign_to.full_path}.",
+        )
+        return redirect("finance:categories")
 
 
 class PreferencesForm(forms.ModelForm):

--- a/finance/views_transactions.py
+++ b/finance/views_transactions.py
@@ -163,6 +163,12 @@ class TransactionListView(FinanceAccessMixin, ListView):
         context["page_title"] = "Activity"
         context["accounts"] = all_accounts
         context["categories"] = all_categories
+        # Archived categories stay assignable — just tucked into their own
+        # section at the bottom of the picker, so old data stays readable
+        # without cluttering the choices for new transactions.
+        context["archived_categories"] = Category.objects.filter(
+            is_active=False, children__isnull=True
+        ).select_related("parent").alphabetical()
         context["budgets"] = Budget.objects.filter(is_active=True).order_by("name")
         context["review_only"] = self.request.GET.get("review") == "1"
         context["review_count"] = Transaction.objects.filter(needs_review=True).count()

--- a/static/css/tailwind.css
+++ b/static/css/tailwind.css
@@ -1233,6 +1233,10 @@ video {
   margin-bottom: 2rem;
 }
 
+.ml-1 {
+  margin-left: 0.25rem;
+}
+
 .mt-0\.5 {
   margin-top: 0.125rem;
 }
@@ -2034,6 +2038,10 @@ video {
   line-height: 1;
 }
 
+.text-\[10px\] {
+  font-size: 10px;
+}
+
 .text-\[11px\] {
   font-size: 11px;
 }
@@ -2256,6 +2264,10 @@ video {
   background-color: rgb(239 68 68 / 0.1);
 }
 
+.hover\:bg-error\/90:hover {
+  background-color: rgb(239 68 68 / 0.9);
+}
+
 .hover\:bg-muted:hover {
   --tw-bg-opacity: 1;
   background-color: rgb(31 41 55 / var(--tw-bg-opacity, 1));
@@ -2428,6 +2440,10 @@ video {
 
   .lg\:grid-cols-4 {
     grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  .lg\:grid-cols-5 {
+    grid-template-columns: repeat(5, minmax(0, 1fr));
   }
 }
 


### PR DESCRIPTION
## Summary
- New **Settings > Categories** page (linked from the Settings home grid): create, rename, archive/unarchive, and delete categories.
- **Create/edit**: name, parent (max 3 levels deep, enforced by the existing model validation), kind, sort order, description. The slug is set once at creation and never changes on rename — several system categories and all `CategoryRule`/`MerchantCategoryMemo` matching depend on it staying stable.
- **Archive** (reuses the existing `Category.is_active` flag): an archived category stays selectable everywhere — it just moves into its own greyed `<optgroup>` at the bottom of the per-transaction category picker on the Activity page, out of the way of the main list.
- **Delete**: shows a confirmation page with counts of affected transactions, category rules, and remembered merchants, and a "move existing transactions to" dropdown defaulting to Uncategorized. Transactions are bulk-reassigned before the category is deleted (`Transaction.category` is `SET_NULL`, so this is the difference between an explicit choice and a silent null-out). Moving to Uncategorized flags those transactions `needs_review`, matching the normal categorization pipeline's own convention; moving anywhere else marks them a confirmed manual assignment.
- System categories (Uncategorized, Internal Transfer, Credit Card Payment) can't be archived or deleted, since the pipeline looks them up by slug.
- A category with subcategories can't be deleted directly — has to be reassigned/removed first, to avoid orphaning a branch of the tree.

## Test plan
- [x] `manage.py test finance` — 573 passing, including a new `CategoryManagementTests` suite (create/rename/cycle-guard/archive/system-protection/delete-with-reassignment/cascade behavior/delete confirmation defaults/auth gating) and two new tests for the archived-category optgroup on the transaction list
- [x] `makemigrations --check --dry-run` — no changes (reuses the existing `is_active` field)
- [x] `manage.py check` — clean
- [x] `npm run tailwind:build` — committed
- Not verified live in-browser (TOTP-gated login isn't set up in this environment) — relying on the test suite above