### PR TITLE
Add multi-select bulk categorization to Activity

### DIFF
--- a/finance/templates/finance/transactions/list.html
+++ b/finance/templates/finance/transactions/list.html
@@ -109,68 +109,126 @@
   </button>
 </form>
 
-<div class="mt-6 space-y-2">
-  {% for txn in transactions %}
-    <div class="rounded-card border border-border bg-surface p-4 {% if txn.needs_review %}border-warning/40{% endif %}">
-      <div class="flex items-start justify-between gap-4">
-        <div class="min-w-0">
-          <p class="truncate font-medium">{{ txn.description_raw }}</p>
-          <p class="mt-1 text-xs text-text-muted">
-            {{ txn.posted_on|date:"j M" }} · {{ txn.account.name }}
-            {% if txn.is_transfer %}· <span class="text-accent">transfer</span>{% endif %}
-            {% if txn.category_source == 'llm' and txn.category_confidence %}
-              · classified {{ txn.category_confidence|floatformat:2 }}
-            {% endif %}
-          </p>
-        </div>
+<div class="mt-6" x-data="{ selected: [], selectAllFiltered: false }">
+  <div class="flex flex-wrap items-center gap-3 rounded-card border border-primary/40 bg-primary/10 px-4 py-3 text-sm"
+       x-show="selected.length > 0 || selectAllFiltered">
+    <span class="font-medium" x-show="!selectAllFiltered" x-text="selected.length + ' selected'"></span>
+    <span class="font-medium" x-show="selectAllFiltered">All {{ page_obj.paginator.count }} matching this filter</span>
 
-        <p class="shrink-0 font-mono text-sm {% if txn.amount < 0 %}text-text-primary{% else %}text-success{% endif %}">
-          {% if txn.amount < 0 %}−{% endif %}${{ txn.display_amount|money }}
-        </p>
-      </div>
+    {% if page_obj.paginator.count > transactions|length %}
+      <label class="flex items-center gap-1.5 text-xs text-text-muted">
+        <input type="checkbox" x-model="selectAllFiltered" @change="if ($event.target.checked) selected = []"
+               class="h-3.5 w-3.5 rounded border-border bg-background text-primary focus:ring-primary" />
+        Select all {{ page_obj.paginator.count }}, not just this page
+      </label>
+    {% endif %}
 
-      <form method="post" class="mt-3 flex flex-wrap items-center gap-2"
-            x-data="{ initial: '{{ txn.category_id|default:'' }}', selected: '{{ txn.category_id|default:'' }}', needsReview: {{ txn.needs_review|yesno:'true,false' }} }">
-        {% csrf_token %}
-        <input type="hidden" name="transaction" value="{{ txn.pk }}" />
-        <input type="hidden" name="next" value="{{ request.get_full_path }}" />
+    <form method="post" action="{{ request.get_full_path }}" class="flex flex-wrap items-center gap-2"
+          onsubmit="return document.getElementById('bulk-all-flag').value !== '1' || confirm('Apply this category to all {{ page_obj.paginator.count }} transactions matching the current filter?')">
+      {% csrf_token %}
+      <input type="hidden" name="action" value="bulk_categorize" />
+      <input type="hidden" name="next" value="{{ request.get_full_path }}" />
+      <input type="hidden" id="bulk-all-flag" name="apply_to_all_filtered" :value="selectAllFiltered ? '1' : ''" />
+      <template x-for="id in selected" :key="id">
+        <input type="hidden" name="transaction_ids" :value="id" />
+      </template>
 
-        <select name="category" x-model="selected"
-                class="min-w-0 flex-1 rounded-button border border-border bg-background px-3 py-1.5 text-xs focus:outline-none focus:ring-2 focus:ring-primary">
-          {% for category in categories %}
-            <option value="{{ category.pk }}" {% if txn.category_id == category.pk %}selected{% endif %}>{{ category.full_path }}</option>
-          {% endfor %}
-          {% if archived_categories %}
-            <optgroup label="Archived" class="text-text-muted">
-              {% for category in archived_categories %}
-                <option value="{{ category.pk }}" class="text-text-muted" {% if txn.category_id == category.pk %}selected{% endif %}>{{ category.full_path }}</option>
-              {% endfor %}
-            </optgroup>
-          {% endif %}
-        </select>
-
-        <button type="submit" :disabled="selected === initial && !needsReview"
-                class="rounded-button bg-primary px-3 py-1.5 text-xs font-medium text-white transition hover:bg-primary-600 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-primary">
-          Save
-        </button>
-      </form>
-    </div>
-  {% empty %}
-    <div class="rounded-card border border-dashed border-border bg-surface/50 p-8 text-center">
-      <p class="text-text-secondary">
-        {% if review_only %}
-          Nothing left to review.
-        {% elif has_active_filters %}
-          No transactions match these filters — try widening the date range or clearing a filter.
-        {% else %}
-          No transactions yet.
+      <select name="category" required
+              class="min-w-0 flex-1 rounded-button border border-border bg-background px-3 py-1.5 text-xs focus:outline-none focus:ring-2 focus:ring-primary">
+        <option value="" disabled selected>Set category to…</option>
+        {% for category in categories %}
+          <option value="{{ category.pk }}">{{ category.full_path }}</option>
+        {% endfor %}
+        {% if archived_categories %}
+          <optgroup label="Archived">
+            {% for category in archived_categories %}
+              <option value="{{ category.pk }}">{{ category.full_path }}</option>
+            {% endfor %}
+          </optgroup>
         {% endif %}
-      </p>
-      {% if has_active_filters and not review_only %}
-        <a href="{% url 'finance:transactions' %}" class="mt-2 inline-block text-primary hover:underline">Clear all filters</a>
-      {% endif %}
-    </div>
-  {% endfor %}
+      </select>
+
+      <button type="submit"
+              class="rounded-button bg-primary px-3 py-1.5 text-xs font-medium text-white transition hover:bg-primary-600">
+        Apply
+      </button>
+      <button type="button" @click="selected = []; selectAllFiltered = false"
+              class="rounded-button border border-border px-3 py-1.5 text-xs transition hover:bg-muted">
+        Clear
+      </button>
+    </form>
+  </div>
+
+  <div class="mt-2 space-y-2">
+    {% for txn in transactions %}
+      <div class="rounded-card border border-border bg-surface p-4 {% if txn.needs_review %}border-warning/40{% endif %}">
+        <div class="flex items-start gap-3">
+          <input type="checkbox" :value="{{ txn.pk }}" x-model="selected"
+                 class="mt-1.5 h-3.5 w-3.5 shrink-0 rounded border-border bg-background text-primary focus:ring-primary" />
+
+          <div class="min-w-0 flex-1">
+            <div class="flex items-start justify-between gap-4">
+              <div class="min-w-0">
+                <p class="truncate font-medium">{{ txn.description_raw }}</p>
+                <p class="mt-1 text-xs text-text-muted">
+                  {{ txn.posted_on|date:"j M" }} · {{ txn.account.name }}
+                  {% if txn.is_transfer %}· <span class="text-accent">transfer</span>{% endif %}
+                  {% if txn.category_source == 'llm' and txn.category_confidence %}
+                    · classified {{ txn.category_confidence|floatformat:2 }}
+                  {% endif %}
+                </p>
+              </div>
+
+              <p class="shrink-0 font-mono text-sm {% if txn.amount < 0 %}text-text-primary{% else %}text-success{% endif %}">
+                {% if txn.amount < 0 %}−{% endif %}${{ txn.display_amount|money }}
+              </p>
+            </div>
+
+            <form method="post" class="mt-3 flex flex-wrap items-center gap-2"
+                  x-data="{ initial: '{{ txn.category_id|default:'' }}', selected: '{{ txn.category_id|default:'' }}', needsReview: {{ txn.needs_review|yesno:'true,false' }} }">
+              {% csrf_token %}
+              <input type="hidden" name="transaction" value="{{ txn.pk }}" />
+              <input type="hidden" name="next" value="{{ request.get_full_path }}" />
+
+              <select name="category" x-model="selected"
+                      class="min-w-0 flex-1 rounded-button border border-border bg-background px-3 py-1.5 text-xs focus:outline-none focus:ring-2 focus:ring-primary">
+                {% for category in categories %}
+                  <option value="{{ category.pk }}" {% if txn.category_id == category.pk %}selected{% endif %}>{{ category.full_path }}</option>
+                {% endfor %}
+                {% if archived_categories %}
+                  <optgroup label="Archived" class="text-text-muted">
+                    {% for category in archived_categories %}
+                      <option value="{{ category.pk }}" class="text-text-muted" {% if txn.category_id == category.pk %}selected{% endif %}>{{ category.full_path }}</option>
+                    {% endfor %}
+                  </optgroup>
+                {% endif %}
+              </select>
+
+              <button type="submit" :disabled="selected === initial && !needsReview"
+                      class="rounded-button bg-primary px-3 py-1.5 text-xs font-medium text-white transition hover:bg-primary-600 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-primary">
+                Save
+              </button>
+            </form>
+          </div>
+        </div>
+      </div>
+    {% empty %}
+      <div class="rounded-card border border-dashed border-border bg-surface/50 p-8 text-center">
+        <p class="text-text-secondary">
+          {% if review_only %}
+            Nothing left to review.
+          {% elif has_active_filters %}
+            No transactions match these filters — try widening the date range or clearing a filter.
+          {% else %}
+            No transactions yet.
+          {% endif %}
+        </p>
+        {% if has_active_filters and not review_only %}
+          <a href="{% url 'finance:transactions' %}" class="mt-2 inline-block text-primary hover:underline">Clear all filters</a>
+        {% endif %}
+      </div>
+    {% endfor %}
+  </div>
 </div>
 
 {% if is_paginated %}

--- a/finance/tests/test_click_throughs.py
+++ b/finance/tests/test_click_throughs.py
@@ -261,6 +261,113 @@ class TransactionListFilterTests(TestCase):
         self.assertContains(response, "Clear all filters")
 
 
+class BulkCategorizeTests(TestCase):
+    """Selecting several transactions at once and setting their category in
+    one action, either by explicit id or by reapplying the page's current
+    filters to the full matching set."""
+
+    def setUp(self):
+        call_command("seed_finance_categories", verbosity=0)
+
+        self.institution = make_institution()
+        self.checking = make_account(self.institution, name="Checking")
+        self.groceries = Category.objects.get(slug="food-groceries")
+        self.restaurants = Category.objects.get(slug="food-restaurants")
+        self.uncategorized = Category.objects.get(slug="uncategorized")
+
+        self.user = make_user("david", with_device=True)
+        self.client.force_login(self.user)
+        session = self.client.session
+        session["otp_device_id"] = TOTPDevice.objects.get(user=self.user).persistent_id
+        session.save()
+
+    def bulk_post(self, **data):
+        data.setdefault("action", "bulk_categorize")
+        return self.client.post(reverse("finance:transactions"), data)
+
+    def test_an_explicit_id_list_only_recategorizes_those_transactions(self):
+        a = make_transaction(self.checking, category=self.groceries, description_raw="A")
+        b = make_transaction(self.checking, category=self.groceries, description_raw="B")
+        untouched = make_transaction(self.checking, category=self.groceries, description_raw="C")
+
+        response = self.bulk_post(
+            category=self.restaurants.pk, transaction_ids=[a.pk, b.pk]
+        )
+
+        self.assertRedirects(response, reverse("finance:transactions"))
+        a.refresh_from_db()
+        b.refresh_from_db()
+        untouched.refresh_from_db()
+        self.assertEqual(a.category, self.restaurants)
+        self.assertEqual(b.category, self.restaurants)
+        self.assertEqual(untouched.category, self.groceries)
+
+    def test_a_bulk_assignment_is_treated_as_a_confirmed_manual_decision(self):
+        txn = make_transaction(
+            self.checking, category=self.groceries, needs_review=True, description_raw="A"
+        )
+
+        self.bulk_post(category=self.restaurants.pk, transaction_ids=[txn.pk])
+
+        txn.refresh_from_db()
+        self.assertEqual(txn.category_source, "manual")
+        self.assertEqual(txn.category_confidence, 1.0)
+        self.assertFalse(txn.needs_review)
+
+    def test_bulk_assigning_to_uncategorized_flags_it_for_review(self):
+        txn = make_transaction(
+            self.checking, category=self.groceries, needs_review=False, description_raw="A"
+        )
+
+        self.bulk_post(category=self.uncategorized.pk, transaction_ids=[txn.pk])
+
+        txn.refresh_from_db()
+        self.assertEqual(txn.category, self.uncategorized)
+        self.assertTrue(txn.needs_review)
+
+    def test_apply_to_all_filtered_reapplies_the_pages_own_filters(self):
+        matching_1 = make_transaction(self.checking, category=self.groceries, description_raw="A")
+        matching_2 = make_transaction(self.checking, category=self.groceries, description_raw="B")
+        other_account = make_account(self.institution, name="Savings")
+        different_account = make_transaction(
+            other_account, category=self.groceries, description_raw="C"
+        )
+
+        filtered_url = f"{reverse('finance:transactions')}?account={self.checking.pk}"
+        response = self.client.post(
+            filtered_url,
+            {
+                "action": "bulk_categorize",
+                "category": self.restaurants.pk,
+                "apply_to_all_filtered": "1",
+            },
+        )
+
+        self.assertRedirects(response, filtered_url)
+        matching_1.refresh_from_db()
+        matching_2.refresh_from_db()
+        different_account.refresh_from_db()
+        self.assertEqual(matching_1.category, self.restaurants)
+        self.assertEqual(matching_2.category, self.restaurants)
+        self.assertEqual(different_account.category, self.groceries)
+
+    def test_an_empty_id_list_recategorizes_nothing(self):
+        txn = make_transaction(self.checking, category=self.groceries, description_raw="A")
+
+        response = self.bulk_post(category=self.restaurants.pk, transaction_ids=[])
+
+        self.assertRedirects(response, reverse("finance:transactions"))
+        txn.refresh_from_db()
+        self.assertEqual(txn.category, self.groceries)
+
+    def test_bulk_categorize_is_gated_like_everything_else(self):
+        self.client.logout()
+
+        response = self.bulk_post(category=self.restaurants.pk, transaction_ids=[])
+
+        self.assertEqual(response.status_code, 403)
+
+
 class MultiSelectFilterTests(TestCase):
     """Accounts, categories, and budgets are all multi-select: OR within one
     filter, AND across different filters — the standard faceted-search

--- a/finance/views_transactions.py
+++ b/finance/views_transactions.py
@@ -24,12 +24,14 @@ transactions at all".
 
 from datetime import date
 
+from django.contrib import messages
 from django.db.models import Q
 from django.shortcuts import get_object_or_404, redirect
 from django.views.generic import ListView
 
 from .access import FinanceAccessMixin
-from .models import Account, Budget, Category, Transaction
+from .categories_seed import UNCATEGORIZED_SLUG
+from .models import Account, Budget, Category, CategorySource, Transaction
 from .redirects import safe_next
 from .services.analytics import spend_filter
 from .services.categorize import confirm_category
@@ -195,15 +197,60 @@ class TransactionListView(FinanceAccessMixin, ListView):
         return context
 
     def post(self, request, *args, **kwargs):
-        """Confirm a category from the list.
+        """Confirm a category from the list, or apply one in bulk.
 
         Standing rules are created from Settings > Category rules instead,
         with the full pattern-matching system available there — not folded
         into this save.
         """
+        if request.POST.get("action") == "bulk_categorize":
+            return self._bulk_categorize(request)
+
         transaction = get_object_or_404(Transaction, pk=request.POST.get("transaction"))
         category = get_object_or_404(Category, pk=request.POST.get("category"))
 
         confirm_category(transaction, category, request.user)
 
+        return redirect(safe_next(request, default=request.get_full_path()))
+
+    def _bulk_categorize(self, request):
+        """Set one category on many transactions at once — either an
+        explicit id list, or every transaction matching the page's current
+        filters (self.get_queryset() reads request.GET, which is populated
+        from the URL regardless of this being a POST, so it sees the exact
+        same filters the page was rendered with).
+
+        Bypasses confirm_category(): that writes a MerchantCategoryMemo per
+        merchant, which doesn't make sense for an arbitrary bulk selection
+        that may span many unrelated merchants."""
+        category = get_object_or_404(Category, pk=request.POST.get("category"))
+
+        if request.POST.get("apply_to_all_filtered") == "1":
+            queryset = self.get_queryset()
+        else:
+            queryset = Transaction.objects.filter(
+                pk__in=request.POST.getlist("transaction_ids")
+            )
+
+        if category.slug == UNCATEGORIZED_SLUG:
+            # Matches services.categorize._assign_uncategorized: parked for
+            # review rather than treated as a confirmed decision.
+            count = queryset.update(
+                category=category,
+                category_source="",
+                category_confidence=0.0,
+                needs_review=True,
+            )
+        else:
+            count = queryset.update(
+                category=category,
+                category_source=CategorySource.MANUAL,
+                category_confidence=1.0,
+                needs_review=False,
+            )
+
+        messages.success(
+            request,
+            f"Set {count} transaction{'s' if count != 1 else ''} to {category.full_path}.",
+        )
         return redirect(safe_next(request, default=request.get_full_path()))

--- a/static/css/tailwind.css
+++ b/static/css/tailwind.css
@@ -1567,6 +1567,10 @@ video {
   gap: 0.25rem;
 }
 
+.gap-1\.5 {
+  gap: 0.375rem;
+}
+
 .gap-2 {
   gap: 0.5rem;
 }


### PR DESCRIPTION
## Summary
- Each transaction row on the Activity page now has a checkbox. Selecting any brings up a toolbar: a category picker and "Apply" button.
- A "Select all N matching this filter, not just this page" option reapplies the page's current filters server-side to the whole matching set (not just the 50 on screen), gated behind a `confirm()` dialog since it can affect far more than what's visible.
- Bulk apply is a plain queryset `.update()` — mirrors the manual-vs-uncategorized distinction the category-delete reassignment flow already uses (assigning to Uncategorized flags `needs_review`; anything else is a confirmed manual assignment). Deliberately doesn't go through `confirm_category()`/write merchant memos, since a bulk selection can span unrelated merchants.
- Per-row Save (added a couple PRs back) is untouched — same POST handler, now branching on an `action` field.

## Test plan
- [x] `manage.py test finance` — 579 passing, including a new `BulkCategorizeTests` suite (explicit id list, manual-vs-uncategorized-review semantics, apply-to-all-filtered reapplying the page's own filters, empty selection is a no-op, auth gating)
- [x] `makemigrations --check --dry-run` — no changes
- [x] `manage.py check` — clean
- [x] `npm run tailwind:build` — committed
- Not verified live in-browser (TOTP-gated login isn't set up in this environment) — relying on the test suite above