### PR TITLE
Fix pagination filter loss + always-visible select-all on Activity

### DIFF
--- a/finance/templates/finance/transactions/list.html
+++ b/finance/templates/finance/transactions/list.html
@@ -123,9 +123,10 @@
     <div class="flex flex-wrap items-center gap-4 text-xs text-text-muted">
       <label class="flex items-center gap-1.5">
         <input type="checkbox"
-               :checked="pageIds.length > 0 && !selectAllFiltered && selected.length === pageIds.length"
+               :checked="selectAllFiltered || (pageIds.length > 0 && selected.length === pageIds.length)"
+               :disabled="selectAllFiltered"
                @change="toggleAllOnPage($event.target.checked)"
-               class="h-3.5 w-3.5 rounded border-border bg-background text-primary focus:ring-primary" />
+               class="h-3.5 w-3.5 rounded border-border bg-background text-primary focus:ring-primary disabled:opacity-60" />
         Select all on this page
       </label>
 
@@ -184,8 +185,11 @@
     {% for txn in transactions %}
       <div class="rounded-card border border-border bg-surface p-4 {% if txn.needs_review %}border-warning/40{% endif %}">
         <div class="flex items-start gap-3">
-          <input type="checkbox" :value="{{ txn.pk }}" x-model="selected"
-                 class="mt-1.5 h-3.5 w-3.5 shrink-0 rounded border-border bg-background text-primary focus:ring-primary" />
+          <input type="checkbox"
+                 :checked="selectAllFiltered || selected.includes({{ txn.pk }})"
+                 :disabled="selectAllFiltered"
+                 @change="$event.target.checked ? selected.push({{ txn.pk }}) : selected = selected.filter(id => id !== {{ txn.pk }})"
+                 class="mt-1.5 h-3.5 w-3.5 shrink-0 rounded border-border bg-background text-primary focus:ring-primary disabled:opacity-60" />
 
           <div class="min-w-0 flex-1">
             <div class="flex items-start justify-between gap-4">

--- a/finance/templates/finance/transactions/list.html
+++ b/finance/templates/finance/transactions/list.html
@@ -109,19 +109,40 @@
   </button>
 </form>
 
-<div class="mt-6" x-data="{ selected: [], selectAllFiltered: false }">
-  <div class="flex flex-wrap items-center gap-3 rounded-card border border-primary/40 bg-primary/10 px-4 py-3 text-sm"
+<div class="mt-6"
+     x-data="{
+       selected: [],
+       selectAllFiltered: false,
+       pageIds: [{% for txn in transactions %}{{ txn.pk }}{% if not forloop.last %},{% endif %}{% endfor %}],
+       toggleAllOnPage(checked) {
+         this.selectAllFiltered = false;
+         this.selected = checked ? this.pageIds.slice() : [];
+       },
+     }">
+  {% if transactions %}
+    <div class="flex flex-wrap items-center gap-4 text-xs text-text-muted">
+      <label class="flex items-center gap-1.5">
+        <input type="checkbox"
+               :checked="pageIds.length > 0 && !selectAllFiltered && selected.length === pageIds.length"
+               @change="toggleAllOnPage($event.target.checked)"
+               class="h-3.5 w-3.5 rounded border-border bg-background text-primary focus:ring-primary" />
+        Select all on this page
+      </label>
+
+      {% if page_obj.paginator.count > transactions|length %}
+        <label class="flex items-center gap-1.5">
+          <input type="checkbox" x-model="selectAllFiltered" @change="if ($event.target.checked) selected = []"
+                 class="h-3.5 w-3.5 rounded border-border bg-background text-primary focus:ring-primary" />
+          Select all {{ page_obj.paginator.count }} matching this filter
+        </label>
+      {% endif %}
+    </div>
+  {% endif %}
+
+  <div class="mt-3 flex flex-wrap items-center gap-3 rounded-card border border-primary/40 bg-primary/10 px-4 py-3 text-sm"
        x-show="selected.length > 0 || selectAllFiltered">
     <span class="font-medium" x-show="!selectAllFiltered" x-text="selected.length + ' selected'"></span>
     <span class="font-medium" x-show="selectAllFiltered">All {{ page_obj.paginator.count }} matching this filter</span>
-
-    {% if page_obj.paginator.count > transactions|length %}
-      <label class="flex items-center gap-1.5 text-xs text-text-muted">
-        <input type="checkbox" x-model="selectAllFiltered" @change="if ($event.target.checked) selected = []"
-               class="h-3.5 w-3.5 rounded border-border bg-background text-primary focus:ring-primary" />
-        Select all {{ page_obj.paginator.count }}, not just this page
-      </label>
-    {% endif %}
 
     <form method="post" action="{{ request.get_full_path }}" class="flex flex-wrap items-center gap-2"
           onsubmit="return document.getElementById('bulk-all-flag').value !== '1' || confirm('Apply this category to all {{ page_obj.paginator.count }} transactions matching the current filter?')">
@@ -233,14 +254,14 @@
 
 {% if is_paginated %}
   <div class="mt-6 flex items-center justify-between text-sm">
-    {% if page_obj.has_previous %}
-      <a href="?page={{ page_obj.previous_page_number }}" class="text-primary hover:underline">← Newer</a>
+    {% if previous_page_url %}
+      <a href="{{ previous_page_url }}" class="text-primary hover:underline">← Newer</a>
     {% else %}<span></span>{% endif %}
 
     <span class="text-text-muted">Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span>
 
-    {% if page_obj.has_next %}
-      <a href="?page={{ page_obj.next_page_number }}" class="text-primary hover:underline">Older →</a>
+    {% if next_page_url %}
+      <a href="{{ next_page_url }}" class="text-primary hover:underline">Older →</a>
     {% else %}<span></span>{% endif %}
   </div>
 {% endif %}

--- a/finance/tests/test_click_throughs.py
+++ b/finance/tests/test_click_throughs.py
@@ -470,6 +470,19 @@ class SelectAllTests(TestCase):
         # "All N matching this filter" status text, which lacks "Select all".
         self.assertNotContains(response, "Select all 1 matching this filter")
 
+    def test_row_checkboxes_visually_reflect_select_all_filtered(self):
+        # Previously bound with x-model, which only ever reflected the
+        # per-id `selected` array — checking "select all N matching this
+        # filter" left every row checkbox looking unchecked even though the
+        # bulk-apply itself correctly targeted the whole filtered set.
+        make_transaction(self.checking, category=self.groceries, description_raw="A")
+
+        response = self.client.get(reverse("finance:transactions"))
+        body = response.content.decode()
+
+        self.assertIn(':checked="selectAllFiltered || selected.includes(', body)
+        self.assertIn(':disabled="selectAllFiltered"', body)
+
 
 class MultiSelectFilterTests(TestCase):
     """Accounts, categories, and budgets are all multi-select: OR within one

--- a/finance/tests/test_click_throughs.py
+++ b/finance/tests/test_click_throughs.py
@@ -12,6 +12,7 @@ from decimal import Decimal
 from django.core.management import call_command
 from django.test import TestCase
 from django.urls import reverse
+from django.utils.html import escape
 from django_otp.plugins.otp_totp.models import TOTPDevice
 
 from finance.models import (
@@ -366,6 +367,108 @@ class BulkCategorizeTests(TestCase):
         response = self.bulk_post(category=self.restaurants.pk, transaction_ids=[])
 
         self.assertEqual(response.status_code, 403)
+
+
+class PaginationPreservesFiltersTests(TestCase):
+    """A page-2 link used to be a bare "?page=2", silently dropping every
+    other active filter — most confusingly review=1, which made "next page"
+    from the review queue look like it dumped you into the full activity
+    list."""
+
+    def setUp(self):
+        call_command("seed_finance_categories", verbosity=0)
+
+        self.institution = make_institution()
+        self.checking = make_account(self.institution, name="Checking")
+        self.groceries = Category.objects.get(slug="food-groceries")
+
+        for i in range(55):
+            make_transaction(
+                self.checking,
+                needs_review=True,
+                category=Category.objects.get(slug="uncategorized"),
+                description_raw=f"NEEDS REVIEW {i}",
+                posted_on=date(2026, 4, 1) + timedelta(days=i % 20),
+            )
+
+        self.user = make_user("david", with_device=True)
+        self.client.force_login(self.user)
+        session = self.client.session
+        session["otp_device_id"] = TOTPDevice.objects.get(user=self.user).persistent_id
+        session.save()
+
+    def test_the_next_page_link_carries_the_review_filter_forward(self):
+        response = self.client.get(reverse("finance:transactions"), {"review": "1"})
+
+        # Both on the SAME link's query string, not just present somewhere
+        # on the page — checked against the actual URL the view built,
+        # rather than against HTML-escaped page content.
+        self.assertIn("review=1", response.context["next_page_url"])
+        self.assertIn("page=2", response.context["next_page_url"])
+        self.assertContains(response, escape(response.context["next_page_url"]))
+
+    def test_the_next_page_link_carries_an_account_filter_forward(self):
+        response = self.client.get(
+            reverse("finance:transactions"), {"account": self.checking.pk}
+        )
+
+        self.assertIn(f"account={self.checking.pk}", response.context["next_page_url"])
+        self.assertIn("page=2", response.context["next_page_url"])
+
+    def test_the_last_page_has_no_next_link(self):
+        response = self.client.get(reverse("finance:transactions"), {"page": 2})
+
+        self.assertIsNone(response.context["next_page_url"])
+        self.assertIn("page=1", response.context["previous_page_url"])
+
+
+class SelectAllTests(TestCase):
+    """Selecting everything shouldn't require clicking each row first."""
+
+    def setUp(self):
+        call_command("seed_finance_categories", verbosity=0)
+
+        self.institution = make_institution()
+        self.checking = make_account(self.institution, name="Checking")
+        self.groceries = Category.objects.get(slug="food-groceries")
+
+        self.user = make_user("david", with_device=True)
+        self.client.force_login(self.user)
+        session = self.client.session
+        session["otp_device_id"] = TOTPDevice.objects.get(user=self.user).persistent_id
+        session.save()
+
+    def test_a_select_all_on_page_control_is_always_present(self):
+        make_transaction(self.checking, category=self.groceries, description_raw="A")
+
+        response = self.client.get(reverse("finance:transactions"))
+
+        self.assertContains(response, "Select all on this page")
+
+    def test_the_select_all_filtered_control_does_not_require_a_prior_selection(self):
+        for i in range(55):
+            make_transaction(
+                self.checking,
+                category=self.groceries,
+                description_raw=f"TXN {i}",
+                posted_on=date(2026, 4, 1) + timedelta(days=i % 20),
+            )
+
+        response = self.client.get(reverse("finance:transactions"))
+        body = response.content.decode()
+
+        # Not nested inside the x-show="selected.length > 0 ..." toolbar --
+        # it must render in markup regardless of Alpine's runtime state.
+        self.assertIn("Select all 55 matching this filter", body)
+
+    def test_no_select_all_filtered_control_when_everything_fits_on_one_page(self):
+        make_transaction(self.checking, category=self.groceries, description_raw="A")
+
+        response = self.client.get(reverse("finance:transactions"))
+
+        # Distinct from the toolbar's always-in-markup (merely hidden)
+        # "All N matching this filter" status text, which lacks "Select all".
+        self.assertNotContains(response, "Select all 1 matching this filter")
 
 
 class MultiSelectFilterTests(TestCase):

--- a/finance/views_transactions.py
+++ b/finance/views_transactions.py
@@ -194,7 +194,28 @@ class TransactionListView(FinanceAccessMixin, ListView):
             "end": self.request.GET.get("end", ""),
         }
 
+        page_obj = context.get("page_obj")
+        if page_obj is not None:
+            # Bare "?page=N" would drop every other active filter (review=1
+            # included) — a page-2 link must carry the rest of the query
+            # string forward, not just replace it.
+            context["previous_page_url"] = (
+                self._page_url(page_obj.previous_page_number())
+                if page_obj.has_previous()
+                else None
+            )
+            context["next_page_url"] = (
+                self._page_url(page_obj.next_page_number())
+                if page_obj.has_next()
+                else None
+            )
+
         return context
+
+    def _page_url(self, page_number):
+        query = self.request.GET.copy()
+        query["page"] = page_number
+        return f"{self.request.path}?{query.urlencode()}"
 
     def post(self, request, *args, **kwargs):
         """Confirm a category from the list, or apply one in bulk.

--- a/static/css/tailwind.css
+++ b/static/css/tailwind.css
@@ -2341,6 +2341,10 @@ video {
   opacity: 0.4;
 }
 
+.disabled\:opacity-60:disabled {
+  opacity: 0.6;
+}
+
 .disabled\:hover\:bg-primary:hover:disabled {
   --tw-bg-opacity: 1;
   background-color: rgb(79 70 229 / var(--tw-bg-opacity, 1));


### PR DESCRIPTION
## Summary
1. **Bug fix**: page-2 links were a bare \`?page=2\`, dropping every other active filter (review=1 included) — clicking to the next page of the review queue silently dumped you into the full, unfiltered activity list. Page URLs are now built server-side by copying the current query string and only replacing \`page\`.
2. **UX**: "select all on this page" and "select all N matching this filter" now render above the list unconditionally (as long as there's at least one transaction), instead of being nested inside the bulk-action toolbar that only appeared after manually checking a row first.

## Test plan
- [x] \`manage.py test finance\` — 586 passing, including new tests for pagination preserving \`review=1\`/\`account=\`, and for both select-all controls rendering without a prior selection
- [x] \`makemigrations --check --dry-run\` — no changes
- [x] \`manage.py check\` — clean
- [x] \`npm run tailwind:build\` — no diff
- [x] Verified live against local preview: confirmed \`Older →\` link carries \`account=1&page=2\` forward, and both select-all controls render on a filtered 1,055-transaction result set with nothing pre-selected