### PR TITLE
Add account/category filters + pagination to Largest Transactions

### DIFF
--- a/finance/services/analytics.py
+++ b/finance/services/analytics.py
@@ -404,22 +404,32 @@ def spend_by_category_over_time(start, end, *, grain="monthly", account_ids=None
     }
 
 
-def largest_transactions(start, end, *, account_ids=None, limit=10):
+def largest_transactions(
+    start, end, *, account_ids=None, category_ids=None, limit=10, offset=0
+):
     """The biggest individual outflows in a window — the one-off expenses
     worth a second look, as distinct from the steady recurring ones.
 
     Only true outflows count (amount < 0): spend_transactions() also matches
     positive refunds against expense categories, which are not "big
     expenses" no matter how large the reimbursement.
+
+    total is the full filtered count, not len(transactions) — the caller
+    needs it to page past `limit` without a second, unpaginated query.
     """
+    queryset = spend_transactions(start, end, account_ids).filter(amount__lt=0)
+
+    if category_ids:
+        queryset = queryset.filter(category_id__in=category_ids)
+
+    total = queryset.count()
     transactions = list(
-        spend_transactions(start, end, account_ids)
-        .filter(amount__lt=0)
-        .select_related("account", "category")
-        .order_by("amount")[:limit]
+        queryset.select_related("account", "category").order_by("amount")[
+            offset : offset + limit
+        ]
     )
 
-    return {"transactions": transactions, "has_data": bool(transactions)}
+    return {"transactions": transactions, "has_data": bool(transactions), "total": total}
 
 
 def recurring_expenses_over_time(

--- a/finance/templates/finance/dashboards/sections/large_transactions.html
+++ b/finance/templates/finance/dashboards/sections/large_transactions.html
@@ -1,24 +1,69 @@
 {% load finance_extras %}
-{% if large_transactions_has_data %}
+{% if large_transactions_available %}
   <section class="rounded-card border border-border bg-surface p-5">
     <div class="flex items-start justify-between gap-3">
       <h2 class="text-sm font-semibold uppercase tracking-wide text-text-muted">Largest transactions</h2>
       {% include "finance/dashboards/_hide_chart_button.html" %}
     </div>
     <p class="mt-1 text-xs text-text-muted">The biggest one-off outflows in this window — worth a second look.</p>
-    <ul class="mt-4 divide-y divide-border">
-      {% for txn in large_transactions %}
-        <li class="flex items-center justify-between gap-3 py-2.5">
-          <div class="min-w-0">
-            <p class="truncate text-sm">{{ txn.description_raw }}</p>
-            <p class="text-xs text-text-muted">
-              {{ txn.posted_on|date:"j M Y" }} · {{ txn.account.name }}
-              {% if txn.category %}· {{ txn.category.name }}{% endif %}
-            </p>
-          </div>
-          <p class="shrink-0 font-mono text-sm">-${{ txn.amount|abs_money }}</p>
-        </li>
-      {% endfor %}
-    </ul>
+
+    <form method="get" class="mt-3 flex flex-wrap items-center gap-2">
+      <input type="hidden" name="range" value="{{ selected_range }}" />
+      <input type="hidden" name="grain" value="{{ selected_grain }}" />
+      {% for account_id in selected_accounts %}<input type="hidden" name="account" value="{{ account_id }}" />{% endfor %}
+
+      <select name="lt_account"
+              class="rounded-button border border-border bg-background px-3 py-1.5 text-xs text-text-primary focus:outline-none focus:ring-2 focus:ring-primary">
+        <option value="">All accounts</option>
+        {% for account in large_transactions_accounts %}
+          <option value="{{ account.pk }}" {% if account.pk|stringformat:"s" in large_transactions_selected_accounts %}selected{% endif %}>{{ account.name }}</option>
+        {% endfor %}
+      </select>
+
+      <select name="lt_category"
+              class="rounded-button border border-border bg-background px-3 py-1.5 text-xs text-text-primary focus:outline-none focus:ring-2 focus:ring-primary">
+        <option value="">All categories</option>
+        {% for category in large_transactions_categories %}
+          <option value="{{ category.pk }}" {% if category.pk|stringformat:"s" in large_transactions_selected_categories %}selected{% endif %}>{{ category.full_path }}</option>
+        {% endfor %}
+      </select>
+
+      <button type="submit" class="rounded-button border border-border bg-surface px-3 py-1.5 text-xs font-medium transition hover:bg-muted">
+        Filter
+      </button>
+    </form>
+
+    {% if large_transactions_has_data %}
+      <ul class="mt-2 divide-y divide-border">
+        {% for txn in large_transactions %}
+          <li class="flex items-center justify-between gap-3 py-2.5">
+            <div class="min-w-0">
+              <p class="truncate text-sm">{{ txn.description_raw }}</p>
+              <p class="text-xs text-text-muted">
+                {{ txn.posted_on|date:"j M Y" }} · {{ txn.account.name }}
+                {% if txn.category %}· {{ txn.category.name }}{% endif %}
+              </p>
+            </div>
+            <p class="shrink-0 font-mono text-sm">-${{ txn.amount|abs_money }}</p>
+          </li>
+        {% endfor %}
+      </ul>
+
+      {% if large_transactions_total_pages > 1 %}
+        <div class="mt-3 flex items-center justify-between text-sm">
+          {% if large_transactions_previous_url %}
+            <a href="{{ large_transactions_previous_url }}" class="text-primary hover:underline">← Newer</a>
+          {% else %}<span></span>{% endif %}
+
+          <span class="text-xs text-text-muted">Page {{ large_transactions_page }} of {{ large_transactions_total_pages }}</span>
+
+          {% if large_transactions_next_url %}
+            <a href="{{ large_transactions_next_url }}" class="text-primary hover:underline">Older →</a>
+          {% else %}<span></span>{% endif %}
+        </div>
+      {% endif %}
+    {% else %}
+      <p class="mt-4 text-sm text-text-muted">No transactions match this filter.</p>
+    {% endif %}
   </section>
 {% endif %}

--- a/finance/tests/test_dashboards.py
+++ b/finance/tests/test_dashboards.py
@@ -692,6 +692,74 @@ class ChartsDashboardRenderTests(AnalyticsTestCase):
         self.assertNotContains(response, "debt-series")
 
 
+class LargeTransactionsSectionTests(AnalyticsTestCase):
+    """The section's own account/category filter and pagination — separate
+    from the page's shared account filter, and from every other chart."""
+
+    def setUp(self):
+        super().setUp()
+        self.sign_in()
+
+    def test_the_filter_form_offers_accounts_and_categories(self):
+        self.spend("-900.00", self.groceries, 5)
+
+        response = self.client.get(reverse("finance:charts"))
+
+        self.assertContains(response, 'name="lt_account"')
+        self.assertContains(response, 'name="lt_category"')
+        self.assertContains(response, self.checking.name)
+        self.assertContains(response, self.groceries.full_path)
+
+    def test_an_lt_category_filter_narrows_the_list_independent_of_page_filters(self):
+        self.spend("-900.00", self.groceries, 5)
+        self.spend("-800.00", self.fuel, 6)
+
+        response = self.client.get(
+            reverse("finance:charts"), {"lt_category": self.fuel.pk}
+        )
+
+        self.assertContains(response, "TXN 4-6 -800.00 transport-fuel")
+        self.assertNotContains(response, "TXN 4-5 -900.00 food-groceries")
+
+    def test_a_filter_matching_nothing_shows_an_empty_state_not_the_whole_section_hiding(self):
+        self.spend("-900.00", self.groceries, 5)
+
+        response = self.client.get(
+            reverse("finance:charts"), {"lt_category": self.fuel.pk}
+        )
+
+        self.assertContains(response, "Largest transactions")
+        self.assertContains(response, "No transactions match this filter.")
+
+    def test_pagination_moves_past_the_first_page(self):
+        for day in range(1, 15):
+            self.spend(f"-{day * 10}.00", self.groceries, day)
+
+        first_page = self.client.get(reverse("finance:charts"))
+        self.assertEqual(len(first_page.context["large_transactions"]), 10)
+        self.assertEqual(first_page.context["large_transactions_total"], 14)
+        self.assertEqual(first_page.context["large_transactions_total_pages"], 2)
+        self.assertIsNotNone(first_page.context["large_transactions_next_url"])
+
+        second_page = self.client.get(reverse("finance:charts"), {"lt_page": 2})
+        self.assertEqual(len(second_page.context["large_transactions"]), 4)
+        self.assertIsNone(second_page.context["large_transactions_next_url"])
+        self.assertIsNotNone(second_page.context["large_transactions_previous_url"])
+
+    def test_the_next_page_link_preserves_the_pages_range_and_account_filter(self):
+        for day in range(1, 15):
+            self.spend(f"-{day * 10}.00", self.groceries, day, account=self.checking)
+
+        response = self.client.get(
+            reverse("finance:charts"), {"range": "12m", "account": self.checking.pk}
+        )
+
+        next_url = response.context["large_transactions_next_url"]
+        self.assertIn("range=12m", next_url)
+        self.assertIn(f"account={self.checking.pk}", next_url)
+        self.assertIn("lt_page=2", next_url)
+
+
 class ChartHideShowTests(AnalyticsTestCase):
     def setUp(self):
         super().setUp()
@@ -866,6 +934,40 @@ class LargestTransactionsAnalyticsTests(AnalyticsTestCase):
 
         self.assertFalse(result["has_data"])
         self.assertEqual(result["transactions"], [])
+
+    def test_a_category_filter_narrows_the_results(self):
+        self.spend("-900.00", self.groceries, 5)
+        self.spend("-800.00", self.fuel, 6)
+
+        result = analytics.largest_transactions(
+            date(2026, 4, 1), date(2026, 4, 30), category_ids=[self.fuel.pk]
+        )
+
+        self.assertEqual(len(result["transactions"]), 1)
+        self.assertEqual(result["transactions"][0].category, self.fuel)
+
+    def test_total_reflects_the_full_filtered_count_not_just_this_page(self):
+        for day in range(1, 6):
+            self.spend(f"-{day * 10}.00", self.groceries, day)
+
+        result = analytics.largest_transactions(
+            date(2026, 4, 1), date(2026, 4, 30), limit=2
+        )
+
+        self.assertEqual(len(result["transactions"]), 2)
+        self.assertEqual(result["total"], 5)
+
+    def test_offset_pages_past_the_first_batch(self):
+        # Descending by amount: -50, -40, -30, -20, -10.
+        for day in range(1, 6):
+            self.spend(f"-{day * 10}.00", self.groceries, day)
+
+        result = analytics.largest_transactions(
+            date(2026, 4, 1), date(2026, 4, 30), limit=2, offset=2
+        )
+
+        amounts = [t.amount for t in result["transactions"]]
+        self.assertEqual(amounts, [Decimal("-30.00"), Decimal("-20.00")])
 
 
 class RecurringExpensesAnalyticsTests(AnalyticsTestCase):

--- a/finance/views_dashboards.py
+++ b/finance/views_dashboards.py
@@ -30,6 +30,7 @@ from .dates import household_today
 from .models import (
     Account,
     Budget,
+    Category,
     DEBT_TYPES,
     SAVINGS_TYPES,
     UserPreference,
@@ -170,6 +171,25 @@ class ChartsView(FinanceView):
         raw = self.request.GET.getlist("balances_account")
         return [int(value) for value in raw if str(value).isdigit()]
 
+    def resolve_large_transactions_accounts(self):
+        # Its own filter too, for the same reason as balances: someone
+        # exploring "what are the biggest one-off outflows" wants to narrow
+        # by account independently of whatever the page's shared filter
+        # happens to be set to.
+        raw = self.request.GET.getlist("lt_account")
+        return [int(value) for value in raw if str(value).isdigit()]
+
+    def resolve_large_transactions_categories(self):
+        raw = self.request.GET.getlist("lt_category")
+        return [int(value) for value in raw if str(value).isdigit()]
+
+    def resolve_large_transactions_page(self):
+        try:
+            page = int(self.request.GET.get("lt_page", 1))
+        except (TypeError, ValueError):
+            return 1
+        return max(1, page)
+
     def known_sections(self):
         return {slug for slug, _ in CHART_SECTION_CHOICES}
 
@@ -243,7 +263,7 @@ class ChartsView(FinanceView):
         context.update(self._spend_context(start, end, grain, account_ids))
         context.update(self._income_context(start, end, grain, account_ids))
         context.update(self._cash_flow_context(start, end, grain, account_ids))
-        context.update(self._large_transactions_context(start, end, account_ids))
+        context.update(self._large_transactions_context(start, end))
         context.update(self._recurring_expenses_context(start, end, grain, account_ids))
         context.update(self._net_worth_context(start, end))
         context.update(self._balances_over_time_context(start, end))
@@ -258,7 +278,7 @@ class ChartsView(FinanceView):
             "spend_over_time": context["spend_has_data"],
             "spend_by_category_trend": context["spend_has_data"],
             "spend_by_category": context["spend_has_data"],
-            "large_transactions": context["large_transactions_has_data"],
+            "large_transactions": context["large_transactions_available"],
             "recurring_expenses": context["recurring_expenses_has_data"],
             "budget_attainment": context["spend_has_data"],
             "net_income": context["income_has_data"],
@@ -273,7 +293,7 @@ class ChartsView(FinanceView):
                 context["spend_has_data"],
                 context["income_has_data"],
                 context["cash_flow_has_data"],
-                context["large_transactions_has_data"],
+                context["large_transactions_available"],
                 context["recurring_expenses_has_data"],
                 context["net_worth_has_data"],
                 context["balances_over_time_available"],
@@ -384,12 +404,55 @@ class ChartsView(FinanceView):
             "cash_flow_has_data": cash_flow["has_data"],
         }
 
-    def _large_transactions_context(self, start, end, account_ids):
-        result = analytics.largest_transactions(start, end, account_ids=account_ids)
+    def _large_transactions_context(self, start, end):
+        per_page = 10
+        selected_accounts = self.resolve_large_transactions_accounts()
+        selected_categories = self.resolve_large_transactions_categories()
+        page = self.resolve_large_transactions_page()
+
+        result = analytics.largest_transactions(
+            start,
+            end,
+            account_ids=selected_accounts or None,
+            category_ids=selected_categories or None,
+            limit=per_page,
+            offset=(page - 1) * per_page,
+        )
+        total_pages = max(1, -(-result["total"] // per_page))
+
+        previous_url = None
+        if page > 1:
+            query = self.request.GET.copy()
+            query["lt_page"] = page - 1
+            previous_url = f"{self.request.path}?{query.urlencode()}"
+
+        next_url = None
+        if page < total_pages:
+            query = self.request.GET.copy()
+            query["lt_page"] = page + 1
+            next_url = f"{self.request.path}?{query.urlencode()}"
 
         return {
             "large_transactions": result["transactions"],
             "large_transactions_has_data": result["has_data"],
+            "large_transactions_total": result["total"],
+            "large_transactions_page": page,
+            "large_transactions_total_pages": total_pages,
+            "large_transactions_previous_url": previous_url,
+            "large_transactions_next_url": next_url,
+            "large_transactions_accounts": Account.objects.filter(is_active=True),
+            "large_transactions_categories": Category.objects.filter(
+                is_active=True, children__isnull=True
+            ).select_related("parent").alphabetical(),
+            "large_transactions_selected_accounts": [str(a) for a in selected_accounts],
+            "large_transactions_selected_categories": [str(c) for c in selected_categories],
+            # Whether the section is available at all, regardless of the
+            # current per-chart filter/page — a filter that happens to match
+            # nothing must not also hide the filter controls themselves, or
+            # there'd be no way back to a wider result.
+            "large_transactions_available": analytics.largest_transactions(
+                start, end, limit=1
+            )["has_data"],
         }
 
     def _recurring_expenses_context(self, start, end, grain, account_ids):


### PR DESCRIPTION
## Summary
- Largest Transactions now has its own account and category filter, independent of the page's shared account filter (same rationale Balances Over Time already uses for its own account filter).
- Replaces the flat top-10 with real pagination — \`largest_transactions()\` takes \`category_ids\`/\`offset\` now and returns the full filtered count, so the view can page 10 at a time without a second unpaginated query.
- Page links are built server-side from a copy of the current query string (same pattern as the Activity page pagination fix in #58), so range/grain/the page's own account filter survive a page click.
- A filter matching nothing shows an empty state within the section instead of hiding the whole thing — mirrors the existing \`balances_over_time_available\` vs. \`balances_over_time_has_data\` split.

## Test plan
- [x] \`manage.py test finance\` — 588 passing, including new analytics tests (category filter, total count vs. page size, offset paging) and view tests (filter form renders, category filter narrows independent of page filters, empty-state-not-hidden, pagination context, next-link preserves range/account)
- [x] \`makemigrations --check --dry-run\` — no changes
- [x] \`manage.py check\` — clean
- [x] \`npm run tailwind:build\` — no diff
- [x] Verified live against local preview: filter form lists all accounts/categories, filtering by "Restaurants" narrows correctly to "Page 1 of 6," and the "Older →" link is \`?range=6m&lt_category=28&lt_page=2\`