### PR TITLE
Shorten "Import Data" nav label to "Import"

### DIFF
--- a/finance/templatetags/finance_nav.py
+++ b/finance/templatetags/finance_nav.py
@@ -20,7 +20,7 @@ PRIMARY_NAV = [
 SECONDARY_NAV = [
     {
         "url_name": "imports",
-        "label": "Import data",
+        "label": "Import",
         "icon": "upload",
         "related": ["import_schemas", "import_upload", "import_map", "import_preview"],
     },

--- a/finance/tests/test_navigation.py
+++ b/finance/tests/test_navigation.py
@@ -60,7 +60,7 @@ class HeaderNavTests(TestCase):
         response = self.client.get(reverse("finance:home"))
         body = response.content.decode()
 
-        self.assertIn("Import data", body)
+        self.assertIn("Import", body)
         self.assertIn(f'href="{reverse("finance:imports")}"', body)
 
     def test_settings_comes_after_import_in_the_desktop_nav(self):


### PR DESCRIPTION
## Summary
- Renames the nav label from "Import Data" to "Import" to fix line-wrapping in the mobile bottom nav bar.

## Test plan
- [x] `manage.py test finance` — 606 passed