### PR TITLE
Extract forms into a package with shared widget styling

### DIFF
--- a/finance/chart_sections.py
+++ b/finance/chart_sections.py
@@ -1,0 +1,25 @@
+"""The Charts tab's sections, declared once.
+
+Both the Charts page and the Preferences page need to know what sections
+exist, what to call them, and what order they come in. Keeping the list here
+rather than in either view means neither has to import the other — Preferences
+used to reach into `views_dashboards` for it, which had forms depending on
+views for no reason other than where the constant happened to live.
+
+Each slug maps to a template partial at
+`finance/dashboards/sections/<slug>.html`.
+"""
+
+CHART_SECTION_CHOICES = [
+    ("spend_over_time", "Spend over time"),
+    ("spend_by_category_trend", "Spend by category, over time"),
+    ("spend_by_category", "Spend by category"),
+    ("large_transactions", "Largest transactions"),
+    ("budget_attainment", "Budget attainment"),
+    ("net_income", "Net income"),
+    ("net_cash_flow", "Net cash flow"),
+    ("net_worth", "Net worth"),
+    ("balances_over_time", "Balances over time"),
+]
+
+CHART_SECTION_SLUGS = [slug for slug, _ in CHART_SECTION_CHOICES]

--- a/finance/forms/__init__.py
+++ b/finance/forms/__init__.py
@@ -1,0 +1,50 @@
+"""Every form in the finance app.
+
+One module per subject rather than forms living inside the view modules that
+happen to render them: a form is reusable and independently testable, and
+several of these (AccountForm, CategoryForm) are used by more than one view.
+
+Re-exported here so callers import from `finance.forms` regardless of which
+module a form lives in.
+"""
+
+from .accounts import AccountForm, BalanceUpdateForm, ManualAccountForm
+from .alerts import AlertForm, ReportForm
+from .auth import FinanceLoginForm, OTPTokenForm
+from .base import StyledFormMixin, style_widget
+from .budgets import BudgetForm
+from .categories import CategoryForm
+from .connections import ConnectionForm
+from .imports import UploadForm
+from .institutions import InstitutionForm
+from .preferences import PreferencesForm
+from .rules import RuleForm
+from .widgets import (
+    AUTH_FIELD_CLASSES,
+    CHECKBOX_CLASSES,
+    FIELD_CLASSES,
+    OTP_FIELD_CLASSES,
+)
+
+__all__ = [
+    "AUTH_FIELD_CLASSES",
+    "CHECKBOX_CLASSES",
+    "FIELD_CLASSES",
+    "OTP_FIELD_CLASSES",
+    "AccountForm",
+    "AlertForm",
+    "BalanceUpdateForm",
+    "BudgetForm",
+    "CategoryForm",
+    "ConnectionForm",
+    "FinanceLoginForm",
+    "InstitutionForm",
+    "ManualAccountForm",
+    "OTPTokenForm",
+    "PreferencesForm",
+    "ReportForm",
+    "RuleForm",
+    "StyledFormMixin",
+    "UploadForm",
+    "style_widget",
+]

--- a/finance/forms/accounts.py
+++ b/finance/forms/accounts.py
@@ -1,0 +1,82 @@
+"""Accounts, and the one-off manual balance reading."""
+
+from django import forms
+
+from ..models import Account, Institution
+from .base import StyledFormMixin
+
+
+class BalanceUpdateForm(StyledFormMixin, forms.Form):
+    """A one-off balance reading, typed in by hand — the lightweight
+    alternative to a full CSV balances import for a single account.
+
+    Deliberately a plain Form, not a ModelForm: saving it does more than set
+    two fields on the Account (see AccountUpdateView._update_balance), it also
+    records an AccountBalanceSnapshot so the reading feeds the same balance
+    history charts a sync or CSV import would.
+    """
+
+    as_of = forms.DateField(
+        label="Balance as of",
+        widget=forms.DateInput(attrs={"type": "date"}),
+    )
+    current_balance = forms.DecimalField(
+        label="Balance",
+        max_digits=12,
+        decimal_places=2,
+        widget=forms.NumberInput(attrs={"step": "0.01"}),
+        help_text="Signed the same way it reads everywhere else in the app — negative for a debt.",
+    )
+    available_balance = forms.DecimalField(
+        label="Available balance",
+        max_digits=12,
+        decimal_places=2,
+        required=False,
+        widget=forms.NumberInput(attrs={"step": "0.01"}),
+    )
+
+
+class AccountForm(StyledFormMixin, forms.ModelForm):
+    class Meta:
+        model = Account
+        fields = [
+            "name", "account_type", "owner", "mask", "debt_reported_positive",
+            "is_active", "include_in_net_worth", "include_in_spending",
+            "sort_order", "notes",
+        ]
+        widgets = {
+            "notes": forms.Textarea(attrs={"rows": 2}),
+        }
+
+
+class ManualAccountForm(StyledFormMixin, forms.ModelForm):
+    """For an account with no connection — the mortgage, the 401(k), anything
+    only ever kept current by a CSV import or by hand. A connected account's
+    institution is set by the sync that discovered it, so this form (and its
+    institution field) is create-only; editing an existing account goes
+    through AccountForm instead."""
+
+    class Meta:
+        model = Account
+        fields = [
+            "institution", "name", "account_type", "owner", "mask",
+            "current_balance", "balance_as_of",
+            "debt_reported_positive", "include_in_net_worth", "include_in_spending",
+            "notes",
+        ]
+        widgets = {
+            "name": forms.TextInput(attrs={"placeholder": "401(k)"}),
+            "current_balance": forms.NumberInput(attrs={"step": "0.01"}),
+            "balance_as_of": forms.DateTimeInput(attrs={"type": "datetime-local"}),
+            "notes": forms.Textarea(attrs={"rows": 2}),
+        }
+        help_texts = {
+            "current_balance": "Optional — leave blank and set it later with a CSV "
+            "balance import if you don't have a figure handy right now.",
+        }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["institution"].queryset = Institution.objects.filter(is_active=True)
+        self.fields["current_balance"].required = False
+        self.fields["balance_as_of"].required = False

--- a/finance/forms/alerts.py
+++ b/finance/forms/alerts.py
@@ -1,0 +1,77 @@
+"""Alerts and scheduled email reports — both personal, not household-wide."""
+
+from django import forms
+
+from ..models import Account, Alert, Budget, ScheduledReport
+from ..services.reports import SECTION_CHOICES
+from .base import StyledFormMixin
+
+
+class AlertForm(StyledFormMixin, forms.ModelForm):
+    class Meta:
+        model = Alert
+        fields = [
+            "name", "kind", "account", "budget", "comparison", "threshold",
+            "threshold_unit", "only_after_period_fraction", "cooldown_hours",
+            "is_active",
+        ]
+        widgets = {
+            "threshold": forms.NumberInput(attrs={"step": "0.01"}),
+            "only_after_period_fraction": forms.NumberInput(
+                attrs={"step": "0.05", "min": 0, "max": 1}
+            ),
+            "cooldown_hours": forms.NumberInput(attrs={"min": 1}),
+        }
+        help_texts = {
+            "threshold": (
+                "A dollar amount, a percentage for budget-percent alerts, or a "
+                "count of the unit below for source-staleness alerts."
+            ),
+            "threshold_unit": "Only used by source-staleness alerts — hours, days, weeks, or months.",
+            "only_after_period_fraction": (
+                "Optional, 0–1. Only fire past this point in the budget period — "
+                "0.5 means 'only in the second half of the month'."
+            ),
+        }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["account"].queryset = Account.objects.filter(is_active=True)
+        self.fields["budget"].queryset = Budget.objects.filter(is_active=True)
+        self.fields["account"].required = False
+        self.fields["budget"].required = False
+        self.fields["threshold_unit"].required = False
+
+
+class ReportForm(StyledFormMixin, forms.ModelForm):
+    sections_selected = forms.MultipleChoiceField(
+        label="Include",
+        choices=SECTION_CHOICES,
+        required=False,
+        widget=forms.CheckboxSelectMultiple(),
+    )
+
+    class Meta:
+        model = ScheduledReport
+        fields = ["name", "cadence", "send_day", "is_active"]
+        widgets = {
+            "send_day": forms.NumberInput(attrs={"min": 1, "max": 28}),
+        }
+        help_texts = {"send_day": "Weekly: 1 is Monday. Monthly: day of the month, 1–28."}
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.instance.pk:
+            self.fields["sections_selected"].initial = self.instance.sections
+
+    def save(self, commit=True):
+        report = super().save(commit=False)
+
+        chosen = set(self.cleaned_data["sections_selected"])
+        # Canonical order, so the email always reads the same way.
+        report.sections = [slug for slug, _ in SECTION_CHOICES if slug in chosen]
+
+        if commit:
+            report.save()
+
+        return report

--- a/finance/forms/auth.py
+++ b/finance/forms/auth.py
@@ -1,17 +1,14 @@
+"""Sign-in and second-factor forms.
+
+Deliberately not using StyledFormMixin: these are the only screens rendered
+signed-out, on an otherwise empty page, and they use the roomier auth sizing
+rather than the app's compact in-app fields.
+"""
+
 from django import forms
 from django.contrib.auth.forms import AuthenticationForm
 
-FIELD_CLASSES = (
-    "w-full rounded-button border border-border bg-background px-4 py-3 "
-    "text-text-primary placeholder:text-text-muted focus:outline-none "
-    "focus:ring-2 focus:ring-primary"
-)
-
-OTP_FIELD_CLASSES = (
-    "w-full rounded-button border border-border bg-background px-4 py-3 "
-    "text-center font-mono text-2xl tracking-[0.4em] text-text-primary "
-    "focus:outline-none focus:ring-2 focus:ring-primary"
-)
+from .widgets import AUTH_FIELD_CLASSES, OTP_FIELD_CLASSES
 
 
 class FinanceLoginForm(AuthenticationForm):
@@ -22,7 +19,7 @@ class FinanceLoginForm(AuthenticationForm):
 
         self.fields["username"].widget.attrs.update(
             {
-                "class": FIELD_CLASSES,
+                "class": AUTH_FIELD_CLASSES,
                 "placeholder": "Username",
                 "autocomplete": "username",
                 "autofocus": True,
@@ -30,7 +27,7 @@ class FinanceLoginForm(AuthenticationForm):
         )
         self.fields["password"].widget.attrs.update(
             {
-                "class": FIELD_CLASSES,
+                "class": AUTH_FIELD_CLASSES,
                 "placeholder": "Password",
                 "autocomplete": "current-password",
             }

--- a/finance/forms/base.py
+++ b/finance/forms/base.py
@@ -11,9 +11,18 @@ from django import forms
 from .widgets import CHECKBOX_CLASSES, FIELD_CLASSES
 
 # Widgets that render a box to tick rather than a box to type in. Note
-# CheckboxSelectMultiple: it renders one <input> per choice and passes its
-# attrs down to each, which is exactly what's wanted here.
-CHECKBOX_WIDGETS = (forms.CheckboxInput, forms.CheckboxSelectMultiple)
+# CheckboxSelectMultiple and RadioSelect: each renders one <input> per choice
+# and passes its attrs down to all of them, which is exactly what's wanted.
+#
+# RadioSelect is here despite no form using one today. The mixin's promise is
+# "styled by widget type", and a promise with a hole in it is worse than no
+# promise — the first radio button added would have rendered as a full-width
+# text input and nobody would have known why.
+CHECKBOX_WIDGETS = (
+    forms.CheckboxInput,
+    forms.CheckboxSelectMultiple,
+    forms.RadioSelect,
+)
 
 # Nothing to style — these render no visible control.
 UNSTYLED_WIDGETS = (forms.HiddenInput, forms.MultipleHiddenInput)

--- a/finance/forms/base.py
+++ b/finance/forms/base.py
@@ -1,0 +1,50 @@
+"""Shared form behavior.
+
+The one thing every form in this app had in common was restating the same
+Tailwind class string on every single widget. `StyledFormMixin` does it once,
+by widget type, so a form's `widgets` declaration is left saying only what is
+actually specific to it — a step size, a min/max, a rows count, a date picker.
+"""
+
+from django import forms
+
+from .widgets import CHECKBOX_CLASSES, FIELD_CLASSES
+
+# Widgets that render a box to tick rather than a box to type in. Note
+# CheckboxSelectMultiple: it renders one <input> per choice and passes its
+# attrs down to each, which is exactly what's wanted here.
+CHECKBOX_WIDGETS = (forms.CheckboxInput, forms.CheckboxSelectMultiple)
+
+# Nothing to style — these render no visible control.
+UNSTYLED_WIDGETS = (forms.HiddenInput, forms.MultipleHiddenInput)
+
+
+def style_widget(widget) -> None:
+    """Give one widget the class it should have, unless it already has one.
+
+    `setdefault` rather than assignment is the important part: a form that
+    genuinely needs different styling (the auth screens, which are roomier)
+    declares its own class and this leaves it alone.
+    """
+    if isinstance(widget, UNSTYLED_WIDGETS):
+        return
+
+    if isinstance(widget, CHECKBOX_WIDGETS):
+        widget.attrs.setdefault("class", CHECKBOX_CLASSES)
+        return
+
+    widget.attrs.setdefault("class", FIELD_CLASSES)
+
+
+class StyledFormMixin:
+    """Applies the app's field styling to every widget on the form.
+
+    Put it first in the bases (`class FooForm(StyledFormMixin, forms.ModelForm)`)
+    so it runs after the fields exist.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        for field in self.fields.values():
+            style_widget(field.widget)

--- a/finance/forms/budgets.py
+++ b/finance/forms/budgets.py
@@ -1,0 +1,42 @@
+"""Budgets — an amount, a reset cycle, and what counts toward it."""
+
+from django import forms
+
+from ..dates import household_today
+from ..models import Account, Budget, Category, CategoryKind
+from .base import StyledFormMixin
+
+
+class BudgetForm(StyledFormMixin, forms.ModelForm):
+    class Meta:
+        model = Budget
+        fields = [
+            "name", "amount", "period_type", "anchor_date",
+            "categories", "accounts", "rollover", "is_active", "notes",
+        ]
+        widgets = {
+            "amount": forms.NumberInput(attrs={"step": "0.01", "min": "0"}),
+            "anchor_date": forms.DateInput(attrs={"type": "date"}),
+            "categories": forms.CheckboxSelectMultiple(),
+            "accounts": forms.CheckboxSelectMultiple(),
+            "notes": forms.Textarea(attrs={"rows": 2}),
+        }
+        help_texts = {
+            "anchor_date": "Sets when the cycle resets — pick a payday for a pay-cycle budget.",
+        }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Transfers and income are never spending, so offering them here would
+        # only produce budgets that can never be met.
+        self.fields["categories"].queryset = Category.objects.filter(
+            is_active=True, kind=CategoryKind.EXPENSE
+        ).select_related("parent").alphabetical()
+
+        self.fields["accounts"].queryset = Account.objects.filter(is_active=True)
+        self.fields["accounts"].required = False
+        self.fields["categories"].required = True
+
+        if not self.instance.pk:
+            self.fields["anchor_date"].initial = household_today().replace(day=1)

--- a/finance/forms/categories.py
+++ b/finance/forms/categories.py
@@ -1,0 +1,75 @@
+"""The category tree."""
+
+from django import forms
+from django.utils.text import slugify
+
+from ..models import Category
+from .base import StyledFormMixin
+
+
+class CategoryForm(StyledFormMixin, forms.ModelForm):
+    """Create or rename a category. The slug is set once, at creation, and
+    never changes after — several system categories (Uncategorized, Internal
+    Transfer, Credit Card Payment) are looked up by slug in code, and a
+    handful of other slugs are what CategoryRule/MerchantCategoryMemo
+    matching keys off of, so renaming a category must not disturb it."""
+
+    class Meta:
+        model = Category
+        fields = ["name", "parent", "kind", "sort_order", "description"]
+        widgets = {
+            "name": forms.TextInput(attrs={"placeholder": "Groceries"}),
+            "description": forms.TextInput(),
+        }
+        help_texts = {
+            "parent": "Leave unset for a top-level category. Nesting goes at most three levels deep.",
+            "kind": "A subcategory must share its parent's kind.",
+            "sort_order": "Lower sorts first among siblings.",
+            "description": "Steers the classifier — say what belongs here and what doesn't.",
+        }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["parent"].queryset = Category.objects.filter(is_active=True)
+        self.fields["parent"].required = False
+        self.fields["parent"].empty_label = "No parent (top-level)"
+        self.fields["description"].required = False
+
+    def clean_parent(self):
+        parent = self.cleaned_data.get("parent")
+
+        if parent and self.instance.pk:
+            # Without this guard, picking one of a category's own descendants
+            # as its new parent creates a cycle — full_path/depth walk parent
+            # links and would loop forever.
+            node = parent
+            while node is not None:
+                if node.pk == self.instance.pk:
+                    raise forms.ValidationError(
+                        "A category can't be nested under one of its own subcategories."
+                    )
+                node = node.parent
+
+        return parent
+
+    def save(self, commit=True):
+        category = super().save(commit=False)
+
+        if not category.slug:
+            category.slug = self._unique_slug(category.name)
+
+        if commit:
+            category.save()
+
+        return category
+
+    def _unique_slug(self, name):
+        base = slugify(name)[:90] or "category"
+        slug = base
+        suffix = 1
+
+        while Category.objects.filter(slug=slug).exclude(pk=self.instance.pk).exists():
+            suffix += 1
+            slug = f"{base}-{suffix}"
+
+        return slug

--- a/finance/forms/connections.py
+++ b/finance/forms/connections.py
@@ -1,0 +1,37 @@
+"""Connecting an institution through a provider."""
+
+from django import forms
+
+from .base import StyledFormMixin
+
+
+class ConnectionForm(StyledFormMixin, forms.Form):
+    """Step one of adding an integration: authenticate.
+
+    No institution field — a single SimpleFIN setup token can cover more than
+    one real institution (that's how SimpleFIN Bridge itself works), so which
+    institution each discovered account belongs to is resolved automatically
+    during sync from the provider's own data, not chosen up front here.
+    """
+
+    label = forms.CharField(
+        label="Name this connection",
+        max_length=120,
+        required=False,
+        widget=forms.TextInput(attrs={"placeholder": "Byline + Capital One (joint)"}),
+        help_text="However you want to recognize this in Settings — it can cover more than one institution.",
+    )
+    setup_token = forms.CharField(
+        label="SimpleFIN setup token",
+        widget=forms.Textarea(
+            attrs={
+                "rows": 4,
+                "placeholder": "Paste the token from bridge.simplefin.org",
+                # Never let a browser or password manager retain a bearer
+                # credential from this box.
+                "autocomplete": "off",
+                "spellcheck": "false",
+            }
+        ),
+        help_text="Single use — SimpleFIN will refuse a token that has already been claimed.",
+    )

--- a/finance/forms/imports.py
+++ b/finance/forms/imports.py
@@ -1,0 +1,32 @@
+"""The CSV upload step of the import wizard."""
+
+from django import forms
+
+from ..models import Account, Institution, RecordType
+from .base import StyledFormMixin
+
+
+class UploadForm(StyledFormMixin, forms.Form):
+    institution = forms.ModelChoiceField(
+        queryset=Institution.objects.filter(is_active=True),
+    )
+    account = forms.ModelChoiceField(
+        queryset=Account.objects.filter(is_active=True),
+        required=False,
+        help_text="Required for transactions and balances.",
+    )
+    record_type = forms.ChoiceField(choices=RecordType.choices)
+    csv_file = forms.FileField(
+        widget=forms.ClearableFileInput(attrs={"accept": ".csv,text/csv"})
+    )
+
+    def clean(self):
+        cleaned = super().clean()
+
+        if cleaned.get("record_type") in {RecordType.TRANSACTIONS, RecordType.BALANCES} and not cleaned.get("account"):
+            raise forms.ValidationError(
+                "Pick the account these rows belong to — transactions and "
+                "balances cannot be filed without one."
+            )
+
+        return cleaned

--- a/finance/forms/institutions.py
+++ b/finance/forms/institutions.py
@@ -1,0 +1,38 @@
+"""Institutions — the banks, brokerages and lenders accounts belong to."""
+
+from django import forms
+from django.utils.text import slugify
+
+from ..models import Institution
+from .base import StyledFormMixin
+
+
+class InstitutionForm(StyledFormMixin, forms.ModelForm):
+    """Every institution goes through here, whether it ends up connected via
+    SimpleFIN or only ever fed by hand-uploaded statements — CSV import and
+    manual accounts both need an Institution to attach to, and until now the
+    only way to create one was the side effect of connecting a SimpleFIN
+    integration."""
+
+    class Meta:
+        model = Institution
+        fields = ["name", "provider", "owner", "website", "notes", "is_active"]
+        widgets = {
+            "name": forms.TextInput(attrs={"placeholder": "Northwestern Mutual"}),
+            "notes": forms.Textarea(attrs={"rows": 3}),
+        }
+        help_texts = {
+            "provider": "How data from here normally arrives — SimpleFIN connects "
+            "automatically; CSV/manual means you'll keep it current by hand.",
+        }
+
+    def save(self, commit=True):
+        institution = super().save(commit=False)
+
+        if not institution.slug:
+            institution.slug = slugify(institution.name)[:140]
+
+        if commit:
+            institution.save()
+
+        return institution

--- a/finance/forms/preferences.py
+++ b/finance/forms/preferences.py
@@ -1,0 +1,151 @@
+"""Per-person display preferences — never household data."""
+
+from django import forms
+
+from ..chart_sections import CHART_SECTION_CHOICES
+from ..models import Account, Budget, UserPreference
+from ..services.widgets import WIDGET_CHOICES
+from .base import StyledFormMixin
+
+
+def _ordered_for_display(saved, all_slugs):
+    """The person's arrangement first, then anything they haven't seen yet.
+
+    Two things at once: slugs retired from the choice list are dropped (a
+    stale saved preference must not outlive the section it names, or the
+    label lookup below KeyErrors the moment Preferences is opened), and
+    newly shipped slugs are appended rather than going missing.
+    """
+    kept = [slug for slug in saved if slug in all_slugs]
+    return kept + [slug for slug in all_slugs if slug not in kept]
+
+
+def _ordered_for_save(order_field, chosen, all_slugs):
+    """What to persist: the drag-and-drop order, filtered to what's ticked.
+
+    Reading the hidden order field rather than the declared choice order is
+    what lets a person actually control placement. A missing or corrupted
+    value (JS disabled, stale form) falls back to the declared order rather
+    than silently dropping every section.
+    """
+    known = set(all_slugs)
+    ordered = [slug for slug in order_field.split(",") if slug in known]
+
+    if not ordered:
+        ordered = list(all_slugs)
+
+    return [slug for slug in ordered if slug in chosen]
+
+
+class PreferencesForm(StyledFormMixin, forms.ModelForm):
+    widgets_selected = forms.MultipleChoiceField(
+        label="Homepage widgets",
+        choices=WIDGET_CHOICES,
+        required=False,
+        widget=forms.CheckboxSelectMultiple(),
+    )
+    # Populated by the drag-and-drop reorder script (finance/js/widget-reorder.js)
+    # as a comma-separated slug list reflecting the on-screen row order —
+    # every WIDGET_CHOICES slug, not just the checked ones, so unchecking and
+    # rechecking a widget doesn't lose its place in the list.
+    widget_order = forms.CharField(required=False, widget=forms.HiddenInput())
+    chart_sections_selected = forms.MultipleChoiceField(
+        label="Charts tab sections",
+        choices=CHART_SECTION_CHOICES,
+        required=False,
+        widget=forms.CheckboxSelectMultiple(),
+    )
+    # Same reorder pattern as widget_order, one section down.
+    chart_section_order_input = forms.CharField(required=False, widget=forms.HiddenInput())
+    accounts_selected = forms.ModelMultipleChoiceField(
+        label="Accounts to show",
+        queryset=Account.objects.filter(is_active=True),
+        required=False,
+        widget=forms.CheckboxSelectMultiple(),
+        help_text="Leave all unchecked to show every account.",
+    )
+    budgets_selected = forms.ModelMultipleChoiceField(
+        label="Budgets to show",
+        queryset=Budget.objects.filter(is_active=True),
+        required=False,
+        widget=forms.CheckboxSelectMultiple(),
+        help_text="Leave all unchecked to show every active budget.",
+    )
+
+    class Meta:
+        model = UserPreference
+        fields = ["recent_transaction_count"]
+        widgets = {
+            "recent_transaction_count": forms.NumberInput(attrs={"min": 1, "max": 50})
+        }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self._widget_slugs = [slug for slug, _ in WIDGET_CHOICES]
+        self._section_slugs = [slug for slug, _ in CHART_SECTION_CHOICES]
+
+        if self.instance.pk:
+            self.fields["widgets_selected"].initial = self.instance.widgets
+            self.fields["accounts_selected"].initial = self.instance.homepage_account_ids
+            self.fields["budgets_selected"].initial = self.instance.homepage_budget_ids
+            self.fields["chart_sections_selected"].initial = [
+                slug for slug in self.instance.chart_section_order
+                if slug in self._section_slugs
+            ]
+
+            ordered = _ordered_for_display(self.instance.widgets, self._widget_slugs)
+            ordered_sections = _ordered_for_display(
+                self.instance.chart_section_order, self._section_slugs
+            )
+        else:
+            ordered = self._widget_slugs
+            ordered_sections = self._section_slugs
+
+        self.fields["widget_order"].initial = ",".join(ordered)
+        self._ordered_slugs = ordered
+
+        self.fields["chart_section_order_input"].initial = ",".join(ordered_sections)
+        self._ordered_section_slugs = ordered_sections
+
+    def ordered_widget_rows(self):
+        """(slug, label, checked) in the order the reorder UI should render them."""
+        checked = set(self.fields["widgets_selected"].initial or [])
+        labels = dict(WIDGET_CHOICES)
+
+        return [(slug, labels[slug], slug in checked) for slug in self._ordered_slugs]
+
+    def ordered_chart_section_rows(self):
+        """(slug, label, checked) for the Charts tab section reorder UI."""
+        checked = set(self.fields["chart_sections_selected"].initial or [])
+        labels = dict(CHART_SECTION_CHOICES)
+
+        return [
+            (slug, labels[slug], slug in checked) for slug in self._ordered_section_slugs
+        ]
+
+    def save(self, commit=True):
+        preference = super().save(commit=False)
+
+        preference.homepage_widgets = _ordered_for_save(
+            self.cleaned_data["widget_order"],
+            set(self.cleaned_data["widgets_selected"]),
+            self._widget_slugs,
+        )
+        preference.chart_sections = _ordered_for_save(
+            self.cleaned_data["chart_section_order_input"],
+            set(self.cleaned_data["chart_sections_selected"]),
+            self._section_slugs,
+        )
+
+        preference.homepage_account_ids = [
+            account.pk for account in self.cleaned_data["accounts_selected"]
+        ]
+        preference.homepage_budget_ids = [
+            budget.pk for budget in self.cleaned_data["budgets_selected"]
+        ]
+
+        if commit:
+            preference.save()
+
+        return preference

--- a/finance/forms/rules.py
+++ b/finance/forms/rules.py
@@ -1,0 +1,47 @@
+"""Deterministic description-pattern → category rules."""
+
+from django import forms
+
+from ..models import Account, Category, CategoryRule
+from .base import StyledFormMixin
+
+
+class RuleForm(StyledFormMixin, forms.ModelForm):
+    """A CategoryRule, editable from Settings rather than only ever created
+    sight-unseen via the review queue's "always" checkbox (which only ever
+    writes a CONTAINS match on the merchant name). The model already
+    supports contains/starts-with/exact/regex matching, optionally scoped
+    to one account or an amount range — this just exposes it."""
+
+    class Meta:
+        model = CategoryRule
+        fields = [
+            "pattern", "match_type", "category", "account",
+            "min_amount", "max_amount", "priority", "notes",
+        ]
+        widgets = {
+            "pattern": forms.TextInput(attrs={"placeholder": "netflix"}),
+            "min_amount": forms.NumberInput(attrs={"step": "0.01"}),
+            "max_amount": forms.NumberInput(attrs={"step": "0.01"}),
+            "notes": forms.TextInput(),
+        }
+        help_texts = {
+            "pattern": "Matched against the transaction's raw description, case-insensitively.",
+            "match_type": "“Contains” is the most forgiving choice when an exact match is unlikely.",
+            "account": "Leave unset to apply everywhere.",
+            "min_amount": "Signed, inclusive lower bound. Leave blank for no lower bound.",
+            "max_amount": "Signed, inclusive upper bound. Leave blank for no upper bound.",
+            "priority": "Lower runs first. The first matching rule wins.",
+        }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["category"].queryset = Category.objects.filter(
+            is_active=True, children__isnull=True
+        ).select_related("parent").alphabetical()
+        self.fields["account"].queryset = Account.objects.filter(is_active=True)
+        self.fields["account"].required = False
+        self.fields["account"].empty_label = "Every account"
+        self.fields["min_amount"].required = False
+        self.fields["max_amount"].required = False
+        self.fields["notes"].required = False

--- a/finance/forms/widgets.py
+++ b/finance/forms/widgets.py
@@ -1,0 +1,39 @@
+"""The app's form field styling, in one place.
+
+These class strings used to be copy-pasted into four view modules and then
+hand-applied to sixty-eight individual widgets. Both halves of that were a
+liability: a styling change meant finding every copy, and a form that forgot
+the `attrs={"class": ...}` on one field rendered that field unstyled with
+nothing to catch it.
+
+Applying them is `StyledFormMixin`'s job (see base.py) — a form should only
+name a widget when it needs a *non-class* attribute.
+"""
+
+# The default: every text input, select, textarea, and date picker on a
+# settings/CRUD screen.
+FIELD_CLASSES = (
+    "w-full rounded-button border border-border bg-background px-3 py-2 text-sm "
+    "text-text-primary focus:outline-none focus:ring-2 focus:ring-primary"
+)
+
+CHECKBOX_CLASSES = (
+    "h-4 w-4 rounded border-border bg-background text-primary focus:ring-primary"
+)
+
+# Roomier, for the signed-out screens — login and TOTP are a single centred
+# card on an otherwise empty page, where the compact in-app sizing reads as
+# cramped rather than dense.
+AUTH_FIELD_CLASSES = (
+    "w-full rounded-button border border-border bg-background px-4 py-3 "
+    "text-text-primary placeholder:text-text-muted focus:outline-none "
+    "focus:ring-2 focus:ring-primary"
+)
+
+# One six-digit code, spaced out so it reads as digits to be checked against
+# a phone rather than as ordinary text.
+OTP_FIELD_CLASSES = (
+    "w-full rounded-button border border-border bg-background px-4 py-3 "
+    "text-center font-mono text-2xl tracking-[0.4em] text-text-primary "
+    "focus:outline-none focus:ring-2 focus:ring-primary"
+)

--- a/finance/views_alerts.py
+++ b/finance/views_alerts.py
@@ -5,67 +5,15 @@ delivered to their own address — so every queryset is scoped to the signed-in
 user rather than to the household.
 """
 
-from django import forms
 from django.contrib import messages
 from django.shortcuts import redirect
 from django.urls import reverse_lazy
 from django.views.generic import CreateView, DeleteView, ListView, UpdateView
 
 from .access import FinanceAccessMixin
-from .models import Account, Alert, Budget, ScheduledReport
-from .services.reports import SECTION_CHOICES, send_report
-
-FIELD_CLASSES = (
-    "w-full rounded-button border border-border bg-background px-3 py-2 text-sm "
-    "text-text-primary focus:outline-none focus:ring-2 focus:ring-primary"
-)
-
-CHECKBOX_CLASSES = (
-    "h-4 w-4 rounded border-border bg-background text-primary focus:ring-primary"
-)
-
-
-class AlertForm(forms.ModelForm):
-    class Meta:
-        model = Alert
-        fields = [
-            "name", "kind", "account", "budget", "comparison", "threshold",
-            "threshold_unit", "only_after_period_fraction", "cooldown_hours",
-            "is_active",
-        ]
-        widgets = {
-            "name": forms.TextInput(attrs={"class": FIELD_CLASSES}),
-            "kind": forms.Select(attrs={"class": FIELD_CLASSES}),
-            "account": forms.Select(attrs={"class": FIELD_CLASSES}),
-            "budget": forms.Select(attrs={"class": FIELD_CLASSES}),
-            "comparison": forms.Select(attrs={"class": FIELD_CLASSES}),
-            "threshold": forms.NumberInput(attrs={"class": FIELD_CLASSES, "step": "0.01"}),
-            "threshold_unit": forms.Select(attrs={"class": FIELD_CLASSES}),
-            "only_after_period_fraction": forms.NumberInput(
-                attrs={"class": FIELD_CLASSES, "step": "0.05", "min": 0, "max": 1}
-            ),
-            "cooldown_hours": forms.NumberInput(attrs={"class": FIELD_CLASSES, "min": 1}),
-            "is_active": forms.CheckboxInput(attrs={"class": CHECKBOX_CLASSES}),
-        }
-        help_texts = {
-            "threshold": (
-                "A dollar amount, a percentage for budget-percent alerts, or a "
-                "count of the unit below for source-staleness alerts."
-            ),
-            "threshold_unit": "Only used by source-staleness alerts — hours, days, weeks, or months.",
-            "only_after_period_fraction": (
-                "Optional, 0–1. Only fire past this point in the budget period — "
-                "0.5 means 'only in the second half of the month'."
-            ),
-        }
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.fields["account"].queryset = Account.objects.filter(is_active=True)
-        self.fields["budget"].queryset = Budget.objects.filter(is_active=True)
-        self.fields["account"].required = False
-        self.fields["budget"].required = False
-        self.fields["threshold_unit"].required = False
+from .forms import AlertForm, ReportForm
+from .models import Alert, ScheduledReport
+from .services.reports import send_report
 
 
 class AlertListView(FinanceAccessMixin, ListView):
@@ -127,45 +75,6 @@ class AlertDeleteView(FinanceAccessMixin, DeleteView):
         context = super().get_context_data(**kwargs)
         context["page_title"] = "Delete alert"
         return context
-
-
-class ReportForm(forms.ModelForm):
-    sections_selected = forms.MultipleChoiceField(
-        label="Include",
-        choices=SECTION_CHOICES,
-        required=False,
-        widget=forms.CheckboxSelectMultiple(attrs={"class": CHECKBOX_CLASSES}),
-    )
-
-    class Meta:
-        model = ScheduledReport
-        fields = ["name", "cadence", "send_day", "is_active"]
-        widgets = {
-            "name": forms.TextInput(attrs={"class": FIELD_CLASSES}),
-            "cadence": forms.Select(attrs={"class": FIELD_CLASSES}),
-            "send_day": forms.NumberInput(attrs={"class": FIELD_CLASSES, "min": 1, "max": 28}),
-            "is_active": forms.CheckboxInput(attrs={"class": CHECKBOX_CLASSES}),
-        }
-        help_texts = {"send_day": "Weekly: 1 is Monday. Monthly: day of the month, 1–28."}
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        if self.instance.pk:
-            self.fields["sections_selected"].initial = self.instance.sections
-
-    def save(self, commit=True):
-        report = super().save(commit=False)
-
-        chosen = set(self.cleaned_data["sections_selected"])
-        # Canonical order, so the email always reads the same way.
-        report.sections = [slug for slug, _ in SECTION_CHOICES if slug in chosen]
-
-        if commit:
-            report.save()
-
-        return report
-
-
 class ReportCreateView(FinanceAccessMixin, CreateView):
     template_name = "finance/alerts/report_form.html"
     form_class = ReportForm

--- a/finance/views_budgets.py
+++ b/finance/views_budgets.py
@@ -5,63 +5,15 @@ grocery budget is fine on the 25th and alarming on the 8th, and "can we afford
 this?" is the question this screen exists to answer.
 """
 
-from django import forms
 from django.contrib import messages
 from django.urls import reverse_lazy
 from django.views.generic import CreateView, DeleteView, ListView, UpdateView
 
-from .dates import household_today
 from .access import FinanceAccessMixin
-from .models import Account, Budget, Category, CategoryKind
+from .dates import household_today
+from .forms import BudgetForm
+from .models import Budget
 from .services.rollups import backfill_budget, roll_up_budget
-
-FIELD_CLASSES = (
-    "w-full rounded-button border border-border bg-background px-3 py-2 text-sm "
-    "text-text-primary focus:outline-none focus:ring-2 focus:ring-primary"
-)
-
-CHECKBOX_CLASSES = (
-    "h-4 w-4 rounded border-border bg-background text-primary focus:ring-primary"
-)
-
-
-class BudgetForm(forms.ModelForm):
-    class Meta:
-        model = Budget
-        fields = [
-            "name", "amount", "period_type", "anchor_date",
-            "categories", "accounts", "rollover", "is_active", "notes",
-        ]
-        widgets = {
-            "name": forms.TextInput(attrs={"class": FIELD_CLASSES}),
-            "amount": forms.NumberInput(attrs={"class": FIELD_CLASSES, "step": "0.01", "min": "0"}),
-            "period_type": forms.Select(attrs={"class": FIELD_CLASSES}),
-            "anchor_date": forms.DateInput(attrs={"class": FIELD_CLASSES, "type": "date"}),
-            "categories": forms.CheckboxSelectMultiple(attrs={"class": CHECKBOX_CLASSES}),
-            "accounts": forms.CheckboxSelectMultiple(attrs={"class": CHECKBOX_CLASSES}),
-            "rollover": forms.CheckboxInput(attrs={"class": CHECKBOX_CLASSES}),
-            "is_active": forms.CheckboxInput(attrs={"class": CHECKBOX_CLASSES}),
-            "notes": forms.Textarea(attrs={"class": FIELD_CLASSES, "rows": 2}),
-        }
-        help_texts = {
-            "anchor_date": "Sets when the cycle resets — pick a payday for a pay-cycle budget.",
-        }
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        # Transfers and income are never spending, so offering them here would
-        # only produce budgets that can never be met.
-        self.fields["categories"].queryset = Category.objects.filter(
-            is_active=True, kind=CategoryKind.EXPENSE
-        ).select_related("parent").alphabetical()
-
-        self.fields["accounts"].queryset = Account.objects.filter(is_active=True)
-        self.fields["accounts"].required = False
-        self.fields["categories"].required = True
-
-        if not self.instance.pk:
-            self.fields["anchor_date"].initial = household_today().replace(day=1)
 
 
 class BudgetListView(FinanceAccessMixin, ListView):

--- a/finance/views_dashboards.py
+++ b/finance/views_dashboards.py
@@ -26,6 +26,7 @@ from urllib.parse import urlencode
 from django.shortcuts import redirect
 from django.urls import reverse
 
+from .chart_sections import CHART_SECTION_CHOICES
 from .dates import household_today
 from .models import (
     Account,
@@ -73,24 +74,6 @@ GRAIN_MIN_RANGE_DAYS = {
     "quarterly": 182,
     "annually": 365,
 }
-
-# Charts tab sections a person can choose to show, hide, and reorder, from
-# Preferences or from the Hide chart / Hidden charts controls on the Charts
-# tab itself — both write to the same UserPreference.chart_sections, so the
-# two are always in sync. Each slug maps to a template partial at
-# finance/dashboards/sections/<slug>.html.
-CHART_SECTION_CHOICES = [
-    ("spend_over_time", "Spend over time"),
-    ("spend_by_category_trend", "Spend by category, over time"),
-    ("spend_by_category", "Spend by category"),
-    ("large_transactions", "Largest transactions"),
-    ("budget_attainment", "Budget attainment"),
-    ("net_income", "Net income"),
-    ("net_cash_flow", "Net cash flow"),
-    ("net_worth", "Net worth"),
-    ("balances_over_time", "Balances over time"),
-]
-
 
 class ChartsView(FinanceView):
     """Shared filter handling: range, resolution, and account selection."""

--- a/finance/views_imports.py
+++ b/finance/views_imports.py
@@ -6,28 +6,21 @@ enough to be dangerous when it isn't, so nothing is written until a person has
 looked at the proposed columns and the resulting preview.
 """
 
-from django import forms
 from django.contrib import messages
 from django.shortcuts import redirect
 from django.views.generic import DetailView, FormView, ListView, TemplateView
 
 from .access import FinanceAccessMixin
+from .forms import UploadForm
 from .models import (
-    Account,
     AmountConvention,
     ImportBatch,
     ImportMapping,
     ImportStatus,
-    Institution,
     RecordType,
     RowStatus,
 )
 from .services.importer import ImportError_, commit_batch, parse_batch, stage_upload
-
-FIELD_CLASSES = (
-    "w-full rounded-button border border-border bg-background px-3 py-2 text-sm "
-    "text-text-primary focus:outline-none focus:ring-2 focus:ring-primary"
-)
 
 # Target fields per record type, and whether the import can proceed without them.
 REQUIRED_FIELDS = {
@@ -94,39 +87,6 @@ RECORD_TYPE_GRAIN = {
         "map whichever ones this employer actually itemizes on the stub."
     ),
 }
-
-
-class UploadForm(forms.Form):
-    institution = forms.ModelChoiceField(
-        queryset=Institution.objects.filter(is_active=True),
-        widget=forms.Select(attrs={"class": FIELD_CLASSES}),
-    )
-    account = forms.ModelChoiceField(
-        queryset=Account.objects.filter(is_active=True),
-        required=False,
-        help_text="Required for transactions and balances.",
-        widget=forms.Select(attrs={"class": FIELD_CLASSES}),
-    )
-    record_type = forms.ChoiceField(
-        choices=RecordType.choices,
-        widget=forms.Select(attrs={"class": FIELD_CLASSES}),
-    )
-    csv_file = forms.FileField(
-        widget=forms.ClearableFileInput(attrs={"class": FIELD_CLASSES, "accept": ".csv,text/csv"})
-    )
-
-    def clean(self):
-        cleaned = super().clean()
-
-        if cleaned.get("record_type") in {RecordType.TRANSACTIONS, RecordType.BALANCES} and not cleaned.get("account"):
-            raise forms.ValidationError(
-                "Pick the account these rows belong to — transactions and "
-                "balances cannot be filed without one."
-            )
-
-        return cleaned
-
-
 class ImportListView(FinanceAccessMixin, ListView):
     template_name = "finance/imports/list.html"
     context_object_name = "batches"

--- a/finance/views_settings.py
+++ b/finance/views_settings.py
@@ -5,21 +5,31 @@ affect the ledger, so both people see the same thing.
 
 Preferences are personal — which widgets, which filters. They affect only how
 one person sees that ledger, so they never touch shared data.
+
+The forms these views render live in `finance/forms/`, not here.
 """
 
-from django import forms
 from django.contrib import messages
 from django.db import transaction as db_transaction
 from django.db.models import Count
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse_lazy
 from django.utils import timezone
-from django.utils.text import slugify
 from django.views.generic import CreateView, FormView, ListView, TemplateView, UpdateView
 
 from .access import FinanceAccessMixin
 from .categories_seed import UNCATEGORIZED_SLUG
 from .dates import household_today
+from .forms import (
+    AccountForm,
+    BalanceUpdateForm,
+    CategoryForm,
+    ConnectionForm,
+    InstitutionForm,
+    ManualAccountForm,
+    PreferencesForm,
+    RuleForm,
+)
 from .models import (
     Account,
     AccountConnection,
@@ -41,18 +51,7 @@ from .providers.base import ProviderError
 from .providers.simplefin import claim_access_url
 from .services.categorize import categorize_transactions
 from .services.sync import record_balance_snapshot, sync_connection
-from .services.widgets import WIDGET_CHOICES
 from .views import FinanceView
-from .views_dashboards import CHART_SECTION_CHOICES
-
-FIELD_CLASSES = (
-    "w-full rounded-button border border-border bg-background px-3 py-2 text-sm "
-    "text-text-primary focus:outline-none focus:ring-2 focus:ring-primary"
-)
-
-CHECKBOX_CLASSES = (
-    "h-4 w-4 rounded border-border bg-background text-primary focus:ring-primary"
-)
 
 
 class SettingsHomeView(FinanceView):
@@ -95,41 +94,6 @@ class SettingsHomeView(FinanceView):
             )
 
         return redirect("finance:settings")
-
-
-class InstitutionForm(forms.ModelForm):
-    """Every institution goes through here, whether it ends up connected via
-    SimpleFIN or only ever fed by hand-uploaded statements — CSV import and
-    manual accounts both need an Institution to attach to, and until now the
-    only way to create one was the side effect of connecting a SimpleFIN
-    integration."""
-
-    class Meta:
-        model = Institution
-        fields = ["name", "provider", "owner", "website", "notes", "is_active"]
-        widgets = {
-            "name": forms.TextInput(attrs={"class": FIELD_CLASSES, "placeholder": "Northwestern Mutual"}),
-            "provider": forms.Select(attrs={"class": FIELD_CLASSES}),
-            "owner": forms.Select(attrs={"class": FIELD_CLASSES}),
-            "website": forms.URLInput(attrs={"class": FIELD_CLASSES}),
-            "notes": forms.Textarea(attrs={"class": FIELD_CLASSES, "rows": 3}),
-            "is_active": forms.CheckboxInput(attrs={"class": CHECKBOX_CLASSES}),
-        }
-        help_texts = {
-            "provider": "How data from here normally arrives — SimpleFIN connects "
-            "automatically; CSV/manual means you'll keep it current by hand.",
-        }
-
-    def save(self, commit=True):
-        institution = super().save(commit=False)
-
-        if not institution.slug:
-            institution.slug = slugify(institution.name)[:140]
-
-        if commit:
-            institution.save()
-
-        return institution
 
 
 class InstitutionListView(FinanceAccessMixin, ListView):
@@ -176,41 +140,6 @@ class InstitutionUpdateView(FinanceAccessMixin, UpdateView):
         response = super().form_valid(form)
         messages.success(self.request, f"Updated {self.object.name}.")
         return response
-
-
-class ConnectionForm(forms.Form):
-    """Step one of adding an integration: authenticate.
-
-    No institution field — a single SimpleFIN setup token can cover more than
-    one real institution (that's how SimpleFIN Bridge itself works), so which
-    institution each discovered account belongs to is resolved automatically
-    during sync from the provider's own data, not chosen up front here.
-    """
-
-    label = forms.CharField(
-        label="Name this connection",
-        max_length=120,
-        required=False,
-        widget=forms.TextInput(
-            attrs={"class": FIELD_CLASSES, "placeholder": "Byline + Capital One (joint)"}
-        ),
-        help_text="However you want to recognize this in Settings — it can cover more than one institution.",
-    )
-    setup_token = forms.CharField(
-        label="SimpleFIN setup token",
-        widget=forms.Textarea(
-            attrs={
-                "class": FIELD_CLASSES,
-                "rows": 4,
-                "placeholder": "Paste the token from bridge.simplefin.org",
-                # Never let a browser or password manager retain a bearer
-                # credential from this box.
-                "autocomplete": "off",
-                "spellcheck": "false",
-            }
-        ),
-        help_text="Single use — SimpleFIN will refuse a token that has already been claimed.",
-    )
 
 
 class ConnectionCreateView(FinanceAccessMixin, FormView):
@@ -323,98 +252,6 @@ class ConnectionDetailView(FinanceAccessMixin, TemplateView):
             )
 
         return redirect("finance:connection_detail", pk=connection.pk)
-
-
-class BalanceUpdateForm(forms.Form):
-    """A one-off balance reading, typed in by hand — the lightweight
-    alternative to a full CSV balances import for a single account.
-
-    Deliberately a plain Form, not a ModelForm: saving it does more than set
-    two fields on the Account (see AccountUpdateView._update_balance), it also
-    records an AccountBalanceSnapshot so the reading feeds the same balance
-    history charts a sync or CSV import would.
-    """
-
-    as_of = forms.DateField(
-        label="Balance as of",
-        widget=forms.DateInput(attrs={"class": FIELD_CLASSES, "type": "date"}),
-    )
-    current_balance = forms.DecimalField(
-        label="Balance",
-        max_digits=12,
-        decimal_places=2,
-        widget=forms.NumberInput(attrs={"class": FIELD_CLASSES, "step": "0.01"}),
-        help_text="Signed the same way it reads everywhere else in the app — negative for a debt.",
-    )
-    available_balance = forms.DecimalField(
-        label="Available balance",
-        max_digits=12,
-        decimal_places=2,
-        required=False,
-        widget=forms.NumberInput(attrs={"class": FIELD_CLASSES, "step": "0.01"}),
-    )
-
-
-class AccountForm(forms.ModelForm):
-    class Meta:
-        model = Account
-        fields = [
-            "name", "account_type", "owner", "mask", "debt_reported_positive",
-            "is_active", "include_in_net_worth", "include_in_spending",
-            "sort_order", "notes",
-        ]
-        widgets = {
-            "name": forms.TextInput(attrs={"class": FIELD_CLASSES}),
-            "account_type": forms.Select(attrs={"class": FIELD_CLASSES}),
-            "owner": forms.Select(attrs={"class": FIELD_CLASSES}),
-            "mask": forms.TextInput(attrs={"class": FIELD_CLASSES}),
-            "sort_order": forms.NumberInput(attrs={"class": FIELD_CLASSES}),
-            "notes": forms.Textarea(attrs={"class": FIELD_CLASSES, "rows": 2}),
-            "debt_reported_positive": forms.CheckboxInput(attrs={"class": CHECKBOX_CLASSES}),
-            "is_active": forms.CheckboxInput(attrs={"class": CHECKBOX_CLASSES}),
-            "include_in_net_worth": forms.CheckboxInput(attrs={"class": CHECKBOX_CLASSES}),
-            "include_in_spending": forms.CheckboxInput(attrs={"class": CHECKBOX_CLASSES}),
-        }
-
-
-class ManualAccountForm(forms.ModelForm):
-    """For an account with no connection — the mortgage, the 401(k), anything
-    only ever kept current by a CSV import or by hand. A connected account's
-    institution is set by the sync that discovered it, so this form (and its
-    institution field) is create-only; editing an existing account goes
-    through AccountForm instead."""
-
-    class Meta:
-        model = Account
-        fields = [
-            "institution", "name", "account_type", "owner", "mask",
-            "current_balance", "balance_as_of",
-            "debt_reported_positive", "include_in_net_worth", "include_in_spending",
-            "notes",
-        ]
-        widgets = {
-            "institution": forms.Select(attrs={"class": FIELD_CLASSES}),
-            "name": forms.TextInput(attrs={"class": FIELD_CLASSES, "placeholder": "401(k)"}),
-            "account_type": forms.Select(attrs={"class": FIELD_CLASSES}),
-            "owner": forms.Select(attrs={"class": FIELD_CLASSES}),
-            "mask": forms.TextInput(attrs={"class": FIELD_CLASSES}),
-            "current_balance": forms.NumberInput(attrs={"class": FIELD_CLASSES, "step": "0.01"}),
-            "balance_as_of": forms.DateTimeInput(attrs={"class": FIELD_CLASSES, "type": "datetime-local"}),
-            "notes": forms.Textarea(attrs={"class": FIELD_CLASSES, "rows": 2}),
-            "debt_reported_positive": forms.CheckboxInput(attrs={"class": CHECKBOX_CLASSES}),
-            "include_in_net_worth": forms.CheckboxInput(attrs={"class": CHECKBOX_CLASSES}),
-            "include_in_spending": forms.CheckboxInput(attrs={"class": CHECKBOX_CLASSES}),
-        }
-        help_texts = {
-            "current_balance": "Optional — leave blank and set it later with a CSV "
-            "balance import if you don't have a figure handy right now.",
-        }
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.fields["institution"].queryset = Institution.objects.filter(is_active=True)
-        self.fields["current_balance"].required = False
-        self.fields["balance_as_of"].required = False
 
 
 class AccountCreateView(FinanceAccessMixin, CreateView):
@@ -537,51 +374,6 @@ class RuleListView(FinanceAccessMixin, ListView):
         return redirect("finance:rules")
 
 
-class RuleForm(forms.ModelForm):
-    """A CategoryRule, editable from Settings rather than only ever created
-    sight-unseen via the review queue's "always" checkbox (which only ever
-    writes a CONTAINS match on the merchant name). The model already
-    supports contains/starts-with/exact/regex matching, optionally scoped
-    to one account or an amount range — this just exposes it."""
-
-    class Meta:
-        model = CategoryRule
-        fields = [
-            "pattern", "match_type", "category", "account",
-            "min_amount", "max_amount", "priority", "notes",
-        ]
-        widgets = {
-            "pattern": forms.TextInput(attrs={"class": FIELD_CLASSES, "placeholder": "netflix"}),
-            "match_type": forms.Select(attrs={"class": FIELD_CLASSES}),
-            "category": forms.Select(attrs={"class": FIELD_CLASSES}),
-            "account": forms.Select(attrs={"class": FIELD_CLASSES}),
-            "min_amount": forms.NumberInput(attrs={"class": FIELD_CLASSES, "step": "0.01"}),
-            "max_amount": forms.NumberInput(attrs={"class": FIELD_CLASSES, "step": "0.01"}),
-            "priority": forms.NumberInput(attrs={"class": FIELD_CLASSES}),
-            "notes": forms.TextInput(attrs={"class": FIELD_CLASSES}),
-        }
-        help_texts = {
-            "pattern": "Matched against the transaction's raw description, case-insensitively.",
-            "match_type": "“Contains” is the most forgiving choice when an exact match is unlikely.",
-            "account": "Leave unset to apply everywhere.",
-            "min_amount": "Signed, inclusive lower bound. Leave blank for no lower bound.",
-            "max_amount": "Signed, inclusive upper bound. Leave blank for no upper bound.",
-            "priority": "Lower runs first. The first matching rule wins.",
-        }
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.fields["category"].queryset = Category.objects.filter(
-            is_active=True, children__isnull=True
-        ).select_related("parent").alphabetical()
-        self.fields["account"].queryset = Account.objects.filter(is_active=True)
-        self.fields["account"].required = False
-        self.fields["account"].empty_label = "Every account"
-        self.fields["min_amount"].required = False
-        self.fields["max_amount"].required = False
-        self.fields["notes"].required = False
-
-
 class RuleCreateView(FinanceAccessMixin, CreateView):
     template_name = "finance/settings/rule_form.html"
     form_class = RuleForm
@@ -600,77 +392,6 @@ class RuleCreateView(FinanceAccessMixin, CreateView):
             f"“{rule.pattern}” now goes to {rule.category}.",
         )
         return super().form_valid(form)
-
-
-class CategoryForm(forms.ModelForm):
-    """Create or rename a category. The slug is set once, at creation, and
-    never changes after — several system categories (Uncategorized, Internal
-    Transfer, Credit Card Payment) are looked up by slug in code, and a
-    handful of other slugs are what CategoryRule/MerchantCategoryMemo
-    matching keys off of, so renaming a category must not disturb it."""
-
-    class Meta:
-        model = Category
-        fields = ["name", "parent", "kind", "sort_order", "description"]
-        widgets = {
-            "name": forms.TextInput(attrs={"class": FIELD_CLASSES, "placeholder": "Groceries"}),
-            "parent": forms.Select(attrs={"class": FIELD_CLASSES}),
-            "kind": forms.Select(attrs={"class": FIELD_CLASSES}),
-            "sort_order": forms.NumberInput(attrs={"class": FIELD_CLASSES}),
-            "description": forms.TextInput(attrs={"class": FIELD_CLASSES}),
-        }
-        help_texts = {
-            "parent": "Leave unset for a top-level category. Nesting goes at most three levels deep.",
-            "kind": "A subcategory must share its parent's kind.",
-            "sort_order": "Lower sorts first among siblings.",
-            "description": "Steers the classifier — say what belongs here and what doesn't.",
-        }
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.fields["parent"].queryset = Category.objects.filter(is_active=True)
-        self.fields["parent"].required = False
-        self.fields["parent"].empty_label = "No parent (top-level)"
-        self.fields["description"].required = False
-
-    def clean_parent(self):
-        parent = self.cleaned_data.get("parent")
-
-        if parent and self.instance.pk:
-            # Without this guard, picking one of a category's own descendants
-            # as its new parent creates a cycle — full_path/depth walk parent
-            # links and would loop forever.
-            node = parent
-            while node is not None:
-                if node.pk == self.instance.pk:
-                    raise forms.ValidationError(
-                        "A category can't be nested under one of its own subcategories."
-                    )
-                node = node.parent
-
-        return parent
-
-    def save(self, commit=True):
-        category = super().save(commit=False)
-
-        if not category.slug:
-            category.slug = self._unique_slug(category.name)
-
-        if commit:
-            category.save()
-
-        return category
-
-    def _unique_slug(self, name):
-        base = slugify(name)[:90] or "category"
-        slug = base
-        suffix = 1
-
-        while Category.objects.filter(slug=slug).exclude(pk=self.instance.pk).exists():
-            suffix += 1
-            slug = f"{base}-{suffix}"
-
-        return slug
 
 
 class CategoryListView(FinanceAccessMixin, ListView):
@@ -826,152 +547,6 @@ class CategoryDeleteView(FinanceAccessMixin, TemplateView):
             f"Deleted {name}. {moved} transaction{'s' if moved != 1 else ''} moved to {reassign_to.full_path}.",
         )
         return redirect("finance:categories")
-
-
-class PreferencesForm(forms.ModelForm):
-    widgets_selected = forms.MultipleChoiceField(
-        label="Homepage widgets",
-        choices=WIDGET_CHOICES,
-        required=False,
-        widget=forms.CheckboxSelectMultiple(attrs={"class": CHECKBOX_CLASSES}),
-    )
-    # Populated by the drag-and-drop reorder script (finance/js/widget-reorder.js)
-    # as a comma-separated slug list reflecting the on-screen row order —
-    # every WIDGET_CHOICES slug, not just the checked ones, so unchecking and
-    # rechecking a widget doesn't lose its place in the list.
-    widget_order = forms.CharField(required=False, widget=forms.HiddenInput())
-    chart_sections_selected = forms.MultipleChoiceField(
-        label="Charts tab sections",
-        choices=CHART_SECTION_CHOICES,
-        required=False,
-        widget=forms.CheckboxSelectMultiple(attrs={"class": CHECKBOX_CLASSES}),
-    )
-    # Same reorder pattern as widget_order, one section down.
-    chart_section_order_input = forms.CharField(required=False, widget=forms.HiddenInput())
-    accounts_selected = forms.ModelMultipleChoiceField(
-        label="Accounts to show",
-        queryset=Account.objects.filter(is_active=True),
-        required=False,
-        widget=forms.CheckboxSelectMultiple(attrs={"class": CHECKBOX_CLASSES}),
-        help_text="Leave all unchecked to show every account.",
-    )
-    budgets_selected = forms.ModelMultipleChoiceField(
-        label="Budgets to show",
-        queryset=Budget.objects.filter(is_active=True),
-        required=False,
-        widget=forms.CheckboxSelectMultiple(attrs={"class": CHECKBOX_CLASSES}),
-        help_text="Leave all unchecked to show every active budget.",
-    )
-
-    class Meta:
-        model = UserPreference
-        fields = ["recent_transaction_count"]
-        widgets = {
-            "recent_transaction_count": forms.NumberInput(
-                attrs={"class": FIELD_CLASSES, "min": 1, "max": 50}
-            )
-        }
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        all_slugs = [slug for slug, _ in WIDGET_CHOICES]
-        all_section_slugs = [slug for slug, _ in CHART_SECTION_CHOICES]
-
-        if self.instance.pk:
-            self.fields["widgets_selected"].initial = self.instance.widgets
-            self.fields["accounts_selected"].initial = self.instance.homepage_account_ids
-            self.fields["budgets_selected"].initial = self.instance.homepage_budget_ids
-            # The chosen widgets first, in the order the person last arranged
-            # them, then anything not yet chosen — so a widget shipped after
-            # they last saved still shows up, at the end rather than nowhere.
-            ordered = list(self.instance.widgets) + [
-                slug for slug in all_slugs if slug not in self.instance.widgets
-            ]
-            # Filtered to slugs that still exist: a section retired from
-            # CHART_SECTION_CHOICES must not linger in an already-saved
-            # preference forever, or this KeyErrors below on the label
-            # lookup the moment someone opens Preferences.
-            saved_sections = [
-                slug for slug in self.instance.chart_section_order
-                if slug in all_section_slugs
-            ]
-            self.fields["chart_sections_selected"].initial = saved_sections
-            ordered_sections = saved_sections + [
-                slug for slug in all_section_slugs if slug not in saved_sections
-            ]
-        else:
-            ordered = all_slugs
-            ordered_sections = all_section_slugs
-
-        self.fields["widget_order"].initial = ",".join(ordered)
-        self._ordered_slugs = ordered
-
-        self.fields["chart_section_order_input"].initial = ",".join(ordered_sections)
-        self._ordered_section_slugs = ordered_sections
-
-    def ordered_widget_rows(self):
-        """(slug, label, checked) in the order the reorder UI should render them."""
-        checked = set(self.fields["widgets_selected"].initial or [])
-        labels = dict(WIDGET_CHOICES)
-
-        return [(slug, labels[slug], slug in checked) for slug in self._ordered_slugs]
-
-    def ordered_chart_section_rows(self):
-        """(slug, label, checked) for the Charts tab section reorder UI."""
-        checked = set(self.fields["chart_sections_selected"].initial or [])
-        labels = dict(CHART_SECTION_CHOICES)
-
-        return [
-            (slug, labels[slug], slug in checked) for slug in self._ordered_section_slugs
-        ]
-
-    def save(self, commit=True):
-        preference = super().save(commit=False)
-
-        # The hidden field carries the drag-and-drop order for every known
-        # widget; filtering it down to what's checked (rather than reading
-        # WIDGET_CHOICES' fixed order) is what lets a person actually control
-        # placement instead of always getting it reset to the declared order.
-        chosen = set(self.cleaned_data["widgets_selected"])
-        known_slugs = {slug for slug, _ in WIDGET_CHOICES}
-        ordered_slugs = [
-            slug
-            for slug in self.cleaned_data["widget_order"].split(",")
-            if slug in known_slugs
-        ]
-        # A missing or corrupted order (JS disabled, stale form) falls back
-        # to the declared order rather than dropping every widget.
-        if not ordered_slugs:
-            ordered_slugs = [slug for slug, _ in WIDGET_CHOICES]
-
-        preference.homepage_widgets = [slug for slug in ordered_slugs if slug in chosen]
-
-        chosen_sections = set(self.cleaned_data["chart_sections_selected"])
-        known_section_slugs = {slug for slug, _ in CHART_SECTION_CHOICES}
-        ordered_section_slugs = [
-            slug
-            for slug in self.cleaned_data["chart_section_order_input"].split(",")
-            if slug in known_section_slugs
-        ]
-        if not ordered_section_slugs:
-            ordered_section_slugs = [slug for slug, _ in CHART_SECTION_CHOICES]
-
-        preference.chart_sections = [
-            slug for slug in ordered_section_slugs if slug in chosen_sections
-        ]
-
-        preference.homepage_account_ids = [
-            account.pk for account in self.cleaned_data["accounts_selected"]
-        ]
-        preference.homepage_budget_ids = [
-            budget.pk for budget in self.cleaned_data["budgets_selected"]
-        ]
-
-        if commit:
-            preference.save()
-
-        return preference
 
 
 class PreferencesView(FinanceAccessMixin, UpdateView):


### PR DESCRIPTION
Stacked on [#65](https://github.com/dimays/datamays/pull/65) — review that first.

## The problem

Four view modules each carried a byte-identical copy of `FIELD_CLASSES` and `CHECKBOX_CLASSES`, then hand-applied them to **68** individual widgets:

| Module | `FIELD_CLASSES` uses |
|---|---|
| `views_settings.py` | 39 |
| `views_alerts.py` | 13 |
| `views_budgets.py` | 6 |
| `views_imports.py` | 5 |
| `forms.py` | 5 |

A styling change meant finding every copy, and a field that forgot its `attrs` rendered unstyled with nothing to catch it.

## The change

`StyledFormMixin` applies the class by widget type in `__init__`, using `setdefault` so a form that genuinely needs different styling — the roomier signed-out auth screens — keeps its own. Forms now declare `widgets` only for attributes actually specific to them: `step`, `min`/`max`, `rows`, `placeholder`, `type=date`.

Forms move out of the view modules into `finance/forms/`, one module per subject, re-exported from `__init__` so callers still write `from finance.forms import AccountForm`.

Also adds `finance/chart_sections.py`. The chart section list lived in `views_dashboards`, which meant the Preferences *form* imported from a *view* — backwards, and it now has its own home.

```
views_settings.py  993 → 568   (-425)
views_alerts.py    212 → 121    (-91)
views_budgets.py   154 → 106    (-48)
views_imports.py   347 → 307    (-40)
```

## How I verified nothing changed visually

Rendered all 13 forms on `main` and on this branch, then diffed with attribute order normalized (the mixin sets `class` in `__init__`, so it lands after `maxlength=` rather than before — semantically irrelevant, but it makes a raw diff noisy).

**Exactly one semantic difference across all 13 forms**, and it's the intended `recognise` → `recognize` carried in from #65.

## Test plan
- [x] `manage.py test finance` — 607 passed
- [x] `manage.py check` + `makemigrations --check` — clean
- [x] Rendered-HTML diff vs `main` — 1 intended difference, 0 unintended
- [x] Browser: rule form and preferences render correctly, no console errors