### PR TITLE
Draw every chart section from one card template

### DIFF
--- a/finance/chart_sections.py
+++ b/finance/chart_sections.py
@@ -3,23 +3,84 @@
 Both the Charts page and the Preferences page need to know what sections
 exist, what to call them, and what order they come in. Keeping the list here
 rather than in either view means neither has to import the other — Preferences
-used to reach into the dashboards view module for it, which had forms depending on
-views for no reason other than where the constant happened to live.
+used to reach into the dashboards view module for it, which had forms
+depending on views for no reason beyond where the constant happened to live.
+
+The title and the one-line blurb live here too, not in the templates. Each
+section's card is drawn by `dashboards/_section.html` from this data, so a
+section template contains only what is actually specific to it: its controls
+and its chart. Retitling a section is a one-line edit here rather than a hunt
+through nine near-identical partials.
 
 Each slug maps to a template partial at
-`finance/dashboards/sections/<slug>.html`.
+`finance/dashboards/sections/<slug>.html`, and to a key in the view's
+`section_has_data` map, which decides whether the section renders at all.
 """
 
-CHART_SECTION_CHOICES = [
-    ("spend_over_time", "Spend over time"),
-    ("spend_by_category_trend", "Spend by category, over time"),
-    ("spend_by_category", "Spend by category"),
-    ("large_transactions", "Largest transactions"),
-    ("budget_attainment", "Budget attainment"),
-    ("net_income", "Net income"),
-    ("net_cash_flow", "Net cash flow"),
-    ("net_worth", "Net worth"),
-    ("balances_over_time", "Balances over time"),
+from typing import NamedTuple
+
+
+class ChartSection(NamedTuple):
+    slug: str
+    label: str
+    blurb: str = ""
+
+
+CHART_SECTIONS = [
+    ChartSection(
+        "spend_over_time",
+        "Spend over time",
+        "Total outflow per period. Switch the view to split it by category, "
+        "or to drill into one category's subcategories.",
+    ),
+    ChartSection(
+        "spend_by_category_trend",
+        "Spend by category, over time",
+        "Each line is a category, so a trend jumps out.",
+    ),
+    ChartSection(
+        "spend_by_category",
+        "Spend by category",
+        "Every category, largest first. Break it out to see the subcategories "
+        "beneath each one.",
+    ),
+    ChartSection(
+        "large_transactions",
+        "Largest transactions",
+        "The biggest one-off outflows in this window — worth a second look.",
+    ),
+    ChartSection(
+        "budget_attainment",
+        "Budget attainment",
+        "Actual against target, period by period, for each active budget.",
+    ),
+    ChartSection(
+        "net_income",
+        "Net income",
+        "Every deposit categorized as income, whether or not a payslip was "
+        "imported for it.",
+    ),
+    ChartSection(
+        "net_cash_flow",
+        "Net cash flow",
+        "Income minus spend, per period — above zero is cash building up.",
+    ),
+    ChartSection(
+        "net_worth",
+        "Net worth",
+        "Everything you own minus everything you owe, day by day.",
+    ),
+    ChartSection(
+        "balances_over_time",
+        "Balances over time",
+        "Every account, signed the same way it reads everywhere else — a debt "
+        "is negative.",
+    ),
 ]
 
-CHART_SECTION_SLUGS = [slug for slug, _ in CHART_SECTION_CHOICES]
+CHART_SECTIONS_BY_SLUG = {section.slug: section for section in CHART_SECTIONS}
+
+CHART_SECTION_SLUGS = [section.slug for section in CHART_SECTIONS]
+
+# What the Preferences form's checkbox list is built from.
+CHART_SECTION_CHOICES = [(section.slug, section.label) for section in CHART_SECTIONS]

--- a/finance/chart_sections.py
+++ b/finance/chart_sections.py
@@ -80,7 +80,5 @@ CHART_SECTIONS = [
 
 CHART_SECTIONS_BY_SLUG = {section.slug: section for section in CHART_SECTIONS}
 
-CHART_SECTION_SLUGS = [section.slug for section in CHART_SECTIONS]
-
 # What the Preferences form's checkbox list is built from.
 CHART_SECTION_CHOICES = [(section.slug, section.label) for section in CHART_SECTIONS]

--- a/finance/templates/finance/dashboards/_hide_chart_button.html
+++ b/finance/templates/finance/dashboards/_hide_chart_button.html
@@ -1,13 +1,13 @@
 {% comment %}
-  A "Hide chart" button for one section's card. Relies on `slug` and
+  A "Hide chart" button for one section's card. Relies on `section` and
   `current_path` already being in context — both flow down for free from
-  charts.html's `{% for slug in chart_sections %}` loop, since none of the
-  includes between here and there use `only`.
+  charts.html's `{% for section in visible_sections %}` loop, since none of
+  the includes between here and there use `only`.
 {% endcomment %}
 <form method="post" action="{{ current_path }}">
   {% csrf_token %}
   <input type="hidden" name="action" value="hide_section" />
-  <input type="hidden" name="section" value="{{ slug }}" />
+  <input type="hidden" name="section" value="{{ section.slug }}" />
   <button type="submit"
           class="shrink-0 rounded-button border border-border px-2.5 py-1 text-xs font-medium text-text-secondary transition hover:bg-muted hover:text-text-primary">
     Hide chart

--- a/finance/templates/finance/dashboards/_section.html
+++ b/finance/templates/finance/dashboards/_section.html
@@ -1,0 +1,37 @@
+{% comment %}
+  The card every Charts-tab section is drawn in.
+
+  Sections extend this rather than repeating the scaffold — the card, the
+  header row, the title, the blurb and the Hide chart button were previously
+  copy-pasted into all nine, which is how they drifted into two different
+  header layouts and four different top margins.
+
+  A section supplies only what is its own:
+
+    {% extends "finance/dashboards/_section.html" %}
+    {% block controls %}…optional, sits left of Hide chart…{% endblock %}
+    {% block body %}…the chart…{% endblock %}
+
+  Title and blurb come from `section` (finance/chart_sections.py), and
+  whether the section renders at all is decided by charts.html — not by an
+  `{% if %}` in here, which would be a second copy of the same condition.
+
+  No margin of any kind on this element: the container in charts.html owns
+  the spacing between sections, because these are user-reorderable and a
+  margin declared here changes the rhythm depending on where it lands.
+{% endcomment %}
+<section class="rounded-card border border-border bg-surface p-5">
+  <div class="flex flex-wrap items-center justify-between gap-3">
+    <h2 class="text-sm font-semibold uppercase tracking-wide text-text-muted">{{ section.label }}</h2>
+    <div class="flex flex-wrap items-center gap-3">
+      {% block controls %}{% endblock %}
+      {% include "finance/dashboards/_hide_chart_button.html" %}
+    </div>
+  </div>
+
+  {% if section.blurb %}
+    <p class="mt-1 text-xs text-text-muted">{{ section.blurb }}</p>
+  {% endif %}
+
+  {% block body %}{% endblock %}
+</section>

--- a/finance/templates/finance/dashboards/charts.html
+++ b/finance/templates/finance/dashboards/charts.html
@@ -13,13 +13,21 @@
 {% else %}
   <p class="mt-6 text-sm text-text-muted">{{ start|date:"j M Y" }} — {{ end|date:"j M Y" }}</p>
 
-  {% for slug in chart_sections %}
-    {% if section_has_data|get_item:slug %}
-      <div class="mt-8">
-        {% include "finance/dashboards/sections/"|add:slug|add:".html" %}
-      </div>
-    {% endif %}
-  {% endfor %}
+  {% comment %}
+    The container owns the spacing between sections, not the sections
+    themselves. These are user-reorderable, and per-section margins meant
+    the gap above a card depended on which card it happened to be — four
+    different values stacked on top of this wrapper's own.
+
+    `visible_sections` is already filtered to sections with data, so there
+    is no `{% if %}` here either: each section template used to re-test the
+    same flag the view had just tested to build this list.
+  {% endcomment %}
+  <div class="mt-8 space-y-8">
+    {% for section in visible_sections %}
+      {% include "finance/dashboards/sections/"|add:section.slug|add:".html" %}
+    {% endfor %}
+  </div>
 {% endif %}
 
 {% if hidden_sections %}
@@ -28,13 +36,13 @@
       Hidden charts ({{ hidden_sections|length }})
     </summary>
     <ul class="mt-4 divide-y divide-border">
-      {% for slug, label in hidden_sections %}
+      {% for hidden in hidden_sections %}
         <li class="flex items-center justify-between gap-3 py-2.5">
-          <span class="text-sm">{{ label }}</span>
+          <span class="text-sm">{{ hidden.label }}</span>
           <form method="post" action="{{ current_path }}">
             {% csrf_token %}
             <input type="hidden" name="action" value="show_section" />
-            <input type="hidden" name="section" value="{{ slug }}" />
+            <input type="hidden" name="section" value="{{ hidden.slug }}" />
             <button type="submit" class="rounded-button border border-border px-3 py-1.5 text-xs font-medium transition hover:bg-muted">
               Show chart
             </button>

--- a/finance/templates/finance/dashboards/sections/balances_over_time.html
+++ b/finance/templates/finance/dashboards/sections/balances_over_time.html
@@ -1,37 +1,31 @@
-{% if balances_over_time_available %}
-  <section class="rounded-card border border-border bg-surface p-5">
-    <div class="flex items-start justify-between gap-3">
-      <h2 class="text-sm font-semibold uppercase tracking-wide text-text-muted">Balances over time</h2>
-      {% include "finance/dashboards/_hide_chart_button.html" %}
+{% extends "finance/dashboards/_section.html" %}
+
+{% block body %}
+  <form method="get" class="mt-3 flex flex-wrap items-center gap-2">
+    <input type="hidden" name="range" value="{{ selected_range }}" />
+    <input type="hidden" name="grain" value="{{ selected_grain }}" />
+    {% for account in selected_accounts %}<input type="hidden" name="account" value="{{ account }}" />{% endfor %}
+
+    <select name="balances_account" multiple size="4"
+            class="min-w-[10rem] rounded-button border border-border bg-background px-3 py-1.5 text-xs text-text-primary focus:outline-none focus:ring-2 focus:ring-primary">
+      {% for account in all_accounts %}
+        <option value="{{ account.pk }}" {% if account.pk in selected_balances_accounts %}selected{% endif %}>{{ account.name }}</option>
+      {% endfor %}
+    </select>
+
+    <button type="submit" class="rounded-button border border-border bg-surface px-3 py-1.5 text-xs font-medium transition hover:bg-muted">
+      Filter
+    </button>
+
+    <span class="text-xs text-text-muted">Cmd/Ctrl-click to compare more than one account.</span>
+  </form>
+
+  {% if balances_over_time_has_data %}
+    <div class="mt-4 h-72">
+      <canvas data-chart="lines" data-source="balances-over-time"></canvas>
     </div>
-    <p class="mt-1 text-xs text-text-muted">Every account, signed the same way it reads everywhere else — a debt is negative.</p>
-
-    <form method="get" class="mt-3 flex flex-wrap items-center gap-2">
-      <input type="hidden" name="range" value="{{ selected_range }}" />
-      <input type="hidden" name="grain" value="{{ selected_grain }}" />
-      {% for account in selected_accounts %}<input type="hidden" name="account" value="{{ account }}" />{% endfor %}
-
-      <select name="balances_account" multiple size="4"
-              class="min-w-[10rem] rounded-button border border-border bg-background px-3 py-1.5 text-xs text-text-primary focus:outline-none focus:ring-2 focus:ring-primary">
-        {% for account in all_accounts %}
-          <option value="{{ account.pk }}" {% if account.pk in selected_balances_accounts %}selected{% endif %}>{{ account.name }}</option>
-        {% endfor %}
-      </select>
-
-      <button type="submit" class="rounded-button border border-border bg-surface px-3 py-1.5 text-xs font-medium transition hover:bg-muted">
-        Filter
-      </button>
-
-      <span class="text-xs text-text-muted">Cmd/Ctrl-click to compare more than one account.</span>
-    </form>
-
-    {% if balances_over_time_has_data %}
-      <div class="mt-4 h-72">
-        <canvas data-chart="lines" data-source="balances-over-time"></canvas>
-      </div>
-      {{ balances_over_time_json|json_script:"balances-over-time" }}
-    {% else %}
-      <p class="mt-4 text-sm text-text-muted">No balance history for the selected accounts in this window.</p>
-    {% endif %}
-  </section>
-{% endif %}
+    {{ balances_over_time_json|json_script:"balances-over-time" }}
+  {% else %}
+    <p class="mt-4 text-sm text-text-muted">No balance history for the selected accounts in this window.</p>
+  {% endif %}
+{% endblock %}

--- a/finance/templates/finance/dashboards/sections/budget_attainment.html
+++ b/finance/templates/finance/dashboards/sections/budget_attainment.html
@@ -1,21 +1,17 @@
-{% if spend_has_data %}
-  <section class="mt-4 rounded-card border border-border bg-surface p-5">
-    <div class="flex items-start justify-between gap-3">
-      <h2 class="text-sm font-semibold uppercase tracking-wide text-text-muted">Budget attainment over time</h2>
-      {% include "finance/dashboards/_hide_chart_button.html" %}
-    </div>
-    {{ budget_series_json|json_script:"budget-series" }}
-    <div class="mt-4 space-y-6">
-      {% for budget in budgets %}
-        <div>
-          <p class="text-sm font-medium">{{ budget.name }}</p>
-          <div class="mt-2 h-48">
-            <canvas data-chart="budgets" data-source="budget-series" data-budget="{{ budget.name }}"></canvas>
-          </div>
+{% extends "finance/dashboards/_section.html" %}
+
+{% block body %}
+  {{ budget_series_json|json_script:"budget-series" }}
+  <div class="mt-4 space-y-6">
+    {% for budget in budgets %}
+      <div>
+        <p class="text-sm font-medium">{{ budget.name }}</p>
+        <div class="mt-2 h-48">
+          <canvas data-chart="budgets" data-source="budget-series" data-budget="{{ budget.name }}"></canvas>
         </div>
-      {% empty %}
-        <p class="text-sm text-text-muted">No budgets yet.</p>
-      {% endfor %}
-    </div>
-  </section>
-{% endif %}
+      </div>
+    {% empty %}
+      <p class="text-sm text-text-muted">No budgets yet.</p>
+    {% endfor %}
+  </div>
+{% endblock %}

--- a/finance/templates/finance/dashboards/sections/large_transactions.html
+++ b/finance/templates/finance/dashboards/sections/large_transactions.html
@@ -1,69 +1,63 @@
+{% extends "finance/dashboards/_section.html" %}
 {% load finance_extras %}
-{% if large_transactions_available %}
-  <section class="rounded-card border border-border bg-surface p-5">
-    <div class="flex items-start justify-between gap-3">
-      <h2 class="text-sm font-semibold uppercase tracking-wide text-text-muted">Largest transactions</h2>
-      {% include "finance/dashboards/_hide_chart_button.html" %}
-    </div>
-    <p class="mt-1 text-xs text-text-muted">The biggest one-off outflows in this window — worth a second look.</p>
 
-    <form method="get" class="mt-3 flex flex-wrap items-center gap-2">
-      <input type="hidden" name="range" value="{{ selected_range }}" />
-      <input type="hidden" name="grain" value="{{ selected_grain }}" />
-      {% for account_id in selected_accounts %}<input type="hidden" name="account" value="{{ account_id }}" />{% endfor %}
+{% block body %}
+  <form method="get" class="mt-3 flex flex-wrap items-center gap-2">
+    <input type="hidden" name="range" value="{{ selected_range }}" />
+    <input type="hidden" name="grain" value="{{ selected_grain }}" />
+    {% for account_id in selected_accounts %}<input type="hidden" name="account" value="{{ account_id }}" />{% endfor %}
 
-      <select name="lt_account"
-              class="rounded-button border border-border bg-background px-3 py-1.5 text-xs text-text-primary focus:outline-none focus:ring-2 focus:ring-primary">
-        <option value="">All accounts</option>
-        {% for account in large_transactions_accounts %}
-          <option value="{{ account.pk }}" {% if account.pk|stringformat:"s" in large_transactions_selected_accounts %}selected{% endif %}>{{ account.name }}</option>
-        {% endfor %}
-      </select>
+    <select name="lt_account"
+            class="rounded-button border border-border bg-background px-3 py-1.5 text-xs text-text-primary focus:outline-none focus:ring-2 focus:ring-primary">
+      <option value="">All accounts</option>
+      {% for account in large_transactions_accounts %}
+        <option value="{{ account.pk }}" {% if account.pk|stringformat:"s" in large_transactions_selected_accounts %}selected{% endif %}>{{ account.name }}</option>
+      {% endfor %}
+    </select>
 
-      <select name="lt_category"
-              class="rounded-button border border-border bg-background px-3 py-1.5 text-xs text-text-primary focus:outline-none focus:ring-2 focus:ring-primary">
-        <option value="">All categories</option>
-        {% for category in large_transactions_categories %}
-          <option value="{{ category.pk }}" {% if category.pk|stringformat:"s" in large_transactions_selected_categories %}selected{% endif %}>{{ category.full_path }}</option>
-        {% endfor %}
-      </select>
+    <select name="lt_category"
+            class="rounded-button border border-border bg-background px-3 py-1.5 text-xs text-text-primary focus:outline-none focus:ring-2 focus:ring-primary">
+      <option value="">All categories</option>
+      {% for category in large_transactions_categories %}
+        <option value="{{ category.pk }}" {% if category.pk|stringformat:"s" in large_transactions_selected_categories %}selected{% endif %}>{{ category.full_path }}</option>
+      {% endfor %}
+    </select>
 
-      <button type="submit" class="rounded-button border border-border bg-surface px-3 py-1.5 text-xs font-medium transition hover:bg-muted">
-        Filter
-      </button>
-    </form>
+    <button type="submit" class="rounded-button border border-border bg-surface px-3 py-1.5 text-xs font-medium transition hover:bg-muted">
+      Filter
+    </button>
+  </form>
 
-    {% if large_transactions_has_data %}
-      <ul class="mt-2 divide-y divide-border">
-        {% for txn in large_transactions %}
-          <li class="flex items-center justify-between gap-3 py-2.5">
-            <div class="min-w-0">
-              <p class="truncate text-sm">{{ txn.description_raw }}</p>
-              <p class="text-xs text-text-muted">
-                {{ txn.posted_on|date:"j M Y" }} · {{ txn.account.name }}
-                {% if txn.category %}· {{ txn.category.name }}{% endif %}
-              </p>
-            </div>
-            <p class="shrink-0 font-mono text-sm">-${{ txn.amount|abs_money }}</p>
-          </li>
-        {% endfor %}
-      </ul>
+  {% if large_transactions_has_data %}
+    <ul class="mt-2 divide-y divide-border">
+      {% for txn in large_transactions %}
+        <li class="flex items-center justify-between gap-3 py-2.5">
+          <div class="min-w-0">
+            <p class="truncate text-sm">{{ txn.description_raw }}</p>
+            <p class="text-xs text-text-muted">
+              {{ txn.posted_on|date:"j M Y" }} · {{ txn.account.name }}
+              {% if txn.category %}· {{ txn.category.name }}{% endif %}
+            </p>
+          </div>
+          <p class="shrink-0 font-mono text-sm">-${{ txn.amount|abs_money }}</p>
+        </li>
+      {% endfor %}
+    </ul>
 
-      {% if large_transactions_total_pages > 1 %}
-        <div class="mt-3 flex items-center justify-between text-sm">
-          {% if large_transactions_previous_url %}
-            <a href="{{ large_transactions_previous_url }}" class="text-primary hover:underline">← Newer</a>
-          {% else %}<span></span>{% endif %}
+    {% if large_transactions_total_pages > 1 %}
+      <div class="mt-3 flex items-center justify-between text-sm">
+        {% if large_transactions_previous_url %}
+          <a href="{{ large_transactions_previous_url }}" class="text-primary hover:underline">← Newer</a>
+        {% else %}<span></span>{% endif %}
 
-          <span class="text-xs text-text-muted">Page {{ large_transactions_page }} of {{ large_transactions_total_pages }}</span>
+        <span class="text-xs text-text-muted">Page {{ large_transactions_page }} of {{ large_transactions_total_pages }}</span>
 
-          {% if large_transactions_next_url %}
-            <a href="{{ large_transactions_next_url }}" class="text-primary hover:underline">Older →</a>
-          {% else %}<span></span>{% endif %}
-        </div>
-      {% endif %}
-    {% else %}
-      <p class="mt-4 text-sm text-text-muted">No transactions match this filter.</p>
+        {% if large_transactions_next_url %}
+          <a href="{{ large_transactions_next_url }}" class="text-primary hover:underline">Older →</a>
+        {% else %}<span></span>{% endif %}
+      </div>
     {% endif %}
-  </section>
-{% endif %}
+  {% else %}
+    <p class="mt-4 text-sm text-text-muted">No transactions match this filter.</p>
+  {% endif %}
+{% endblock %}

--- a/finance/templates/finance/dashboards/sections/net_cash_flow.html
+++ b/finance/templates/finance/dashboards/sections/net_cash_flow.html
@@ -1,13 +1,8 @@
-{% if cash_flow_has_data %}
-  <section class="mt-8 rounded-card border border-border bg-surface p-5">
-    <div class="flex items-start justify-between gap-3">
-      <h2 class="text-sm font-semibold uppercase tracking-wide text-text-muted">Net cash flow</h2>
-      {% include "finance/dashboards/_hide_chart_button.html" %}
-    </div>
-    <p class="mt-1 text-xs text-text-muted">Income minus spend, per period — above zero is cash building up.</p>
-    <div class="mt-4 h-64">
-      <canvas data-chart="bar" data-source="cash-flow" data-label="Net cash flow"></canvas>
-    </div>
-    {{ cash_flow_json|json_script:"cash-flow" }}
-  </section>
-{% endif %}
+{% extends "finance/dashboards/_section.html" %}
+
+{% block body %}
+  <div class="mt-4 h-64">
+    <canvas data-chart="bar" data-source="cash-flow" data-label="Net cash flow"></canvas>
+  </div>
+  {{ cash_flow_json|json_script:"cash-flow" }}
+{% endblock %}

--- a/finance/templates/finance/dashboards/sections/net_income.html
+++ b/finance/templates/finance/dashboards/sections/net_income.html
@@ -1,20 +1,13 @@
-{% if income_has_data %}
-  <section class="mt-8 rounded-card border border-border bg-surface p-5">
-    <div class="flex items-start justify-between gap-3">
-      <h2 class="text-sm font-semibold uppercase tracking-wide text-text-muted">Net income</h2>
-      {% include "finance/dashboards/_hide_chart_button.html" %}
-    </div>
-    <p class="mt-1 text-xs text-text-muted">
-      Every deposit categorized as income, whether or not a payslip was imported for it.
-    </p>
-    <div class="mt-4 h-64">
-      <canvas data-chart="bar" data-source="net-income" data-label="Net income"></canvas>
-    </div>
-    {{ net_income_json|json_script:"net-income" }}
-  </section>
+{% extends "finance/dashboards/_section.html" %}
+
+{% block body %}
+  <div class="mt-4 h-64">
+    <canvas data-chart="bar" data-source="net-income" data-label="Net income"></canvas>
+  </div>
+  {{ net_income_json|json_script:"net-income" }}
 
   {% if unmatched_count %}
-    <div class="mt-4 rounded-card border border-border bg-surface/60 p-4">
+    <div class="mt-4 rounded-card border border-border bg-background/60 p-4">
       <p class="text-sm text-text-secondary">
         {{ unmatched_count }} deposit{{ unmatched_count|pluralize }} above with no payslip imported.
       </p>
@@ -26,27 +19,36 @@
     </div>
   {% endif %}
 
+  {% comment %}
+    Payslip detail is nested inside this section rather than sitting beside
+    it as two more top-level cards. It is supplementary to net income and
+    only exists when a payslip happens to have been imported — as siblings,
+    the two would drift away from the figure they explain the moment
+    someone reordered the page.
+  {% endcomment %}
   {% if has_payslip_detail %}
-    <section class="mt-4 rounded-card border border-border bg-surface p-5">
-      <h2 class="text-sm font-semibold uppercase tracking-wide text-text-muted">Gross vs net</h2>
-      <p class="mt-1 text-xs text-text-muted">
-        Optional detail, only for pay periods with an imported payslip.
-      </p>
-      <div class="mt-4 h-64">
-        <canvas data-chart="lines" data-source="payslip-gross"></canvas>
+    <div class="mt-6 space-y-4 border-t border-border pt-5">
+      <div>
+        <h3 class="text-xs font-semibold uppercase tracking-wide text-text-muted">Gross vs net</h3>
+        <p class="mt-1 text-xs text-text-muted">
+          Optional detail, only for pay periods with an imported payslip.
+        </p>
+        <div class="mt-3 h-64">
+          <canvas data-chart="lines" data-source="payslip-gross"></canvas>
+        </div>
+        {{ payslip_gross_json|json_script:"payslip-gross" }}
       </div>
-      {{ payslip_gross_json|json_script:"payslip-gross" }}
-    </section>
 
-    <section class="mt-4 rounded-card border border-border bg-surface p-5">
-      <h2 class="text-sm font-semibold uppercase tracking-wide text-text-muted">Where gross pay goes</h2>
-      <p class="mt-1 text-xs text-text-muted">
-        Retirement and HSA are shown apart from tax — that money is still yours.
-      </p>
-      <div class="mt-4 h-64">
-        <canvas data-chart="lines" data-source="payslip-breakdown"></canvas>
+      <div>
+        <h3 class="text-xs font-semibold uppercase tracking-wide text-text-muted">Where gross pay goes</h3>
+        <p class="mt-1 text-xs text-text-muted">
+          Retirement and HSA are shown apart from tax — that money is still yours.
+        </p>
+        <div class="mt-3 h-64">
+          <canvas data-chart="lines" data-source="payslip-breakdown"></canvas>
+        </div>
+        {{ payslip_breakdown_json|json_script:"payslip-breakdown" }}
       </div>
-      {{ payslip_breakdown_json|json_script:"payslip-breakdown" }}
-    </section>
+    </div>
   {% endif %}
-{% endif %}
+{% endblock %}

--- a/finance/templates/finance/dashboards/sections/net_worth.html
+++ b/finance/templates/finance/dashboards/sections/net_worth.html
@@ -1,13 +1,8 @@
-{% if net_worth_has_data %}
-  <section class="rounded-card border border-border bg-surface p-5">
-    <div class="flex items-start justify-between gap-3">
-      <h2 class="text-sm font-semibold uppercase tracking-wide text-text-muted">Net worth</h2>
-      {% include "finance/dashboards/_hide_chart_button.html" %}
-    </div>
-    <p class="mt-1 text-xs text-text-muted">Everything you own minus everything you owe, day by day.</p>
-    <div class="mt-4 h-64">
-      <canvas data-chart="line" data-source="net-worth" data-label="Net worth"></canvas>
-    </div>
-    {{ net_worth_json|json_script:"net-worth" }}
-  </section>
-{% endif %}
+{% extends "finance/dashboards/_section.html" %}
+
+{% block body %}
+  <div class="mt-4 h-64">
+    <canvas data-chart="line" data-source="net-worth" data-label="Net worth"></canvas>
+  </div>
+  {{ net_worth_json|json_script:"net-worth" }}
+{% endblock %}

--- a/finance/templates/finance/dashboards/sections/spend_by_category.html
+++ b/finance/templates/finance/dashboards/sections/spend_by_category.html
@@ -1,20 +1,17 @@
-{% if spend_has_data %}
-  <section class="mt-4 rounded-card border border-border bg-surface p-5">
-    <div class="flex flex-wrap items-center justify-between gap-3">
-      <h2 class="text-sm font-semibold uppercase tracking-wide text-text-muted">Spend by category</h2>
-      <div class="flex items-center gap-3">
-        <label class="flex items-center gap-1.5 whitespace-nowrap text-xs text-text-muted">
-          <input type="checkbox" data-breakout-toggle="spend-by-category-breakdown"
-                 class="h-3.5 w-3.5 rounded border-border bg-background text-primary focus:ring-primary" />
-          Breakout by subcategory
-        </label>
-        {% include "finance/dashboards/_hide_chart_button.html" %}
-      </div>
-    </div>
-    <div class="mt-4 max-h-[28rem] overflow-y-auto">
-      <canvas data-chart="categoryBreakdown" data-source="spend-by-category-breakdown"
-              data-breakout-target="spend-by-category-breakdown"></canvas>
-    </div>
-    {{ spend_by_category_breakdown_json|json_script:"spend-by-category-breakdown" }}
-  </section>
-{% endif %}
+{% extends "finance/dashboards/_section.html" %}
+
+{% block controls %}
+  <label class="flex items-center gap-1.5 whitespace-nowrap text-xs text-text-muted">
+    <input type="checkbox" data-breakout-toggle="spend-by-category-breakdown"
+           class="h-3.5 w-3.5 rounded border-border bg-background text-primary focus:ring-primary" />
+    Breakout by subcategory
+  </label>
+{% endblock %}
+
+{% block body %}
+  <div class="mt-4 max-h-[28rem] overflow-y-auto">
+    <canvas data-chart="categoryBreakdown" data-source="spend-by-category-breakdown"
+            data-breakout-target="spend-by-category-breakdown"></canvas>
+  </div>
+  {{ spend_by_category_breakdown_json|json_script:"spend-by-category-breakdown" }}
+{% endblock %}

--- a/finance/templates/finance/dashboards/sections/spend_by_category_trend.html
+++ b/finance/templates/finance/dashboards/sections/spend_by_category_trend.html
@@ -1,13 +1,8 @@
-{% if spend_has_data %}
-  <section class="mt-4 rounded-card border border-border bg-surface p-5">
-    <div class="flex items-start justify-between gap-3">
-      <h2 class="text-sm font-semibold uppercase tracking-wide text-text-muted">Spend by category, over time</h2>
-      {% include "finance/dashboards/_hide_chart_button.html" %}
-    </div>
-    <p class="mt-1 text-xs text-text-muted">Each line is a category, so a trend jumps out.</p>
-    <div class="mt-4 h-72">
-      <canvas data-chart="lines" data-source="spend-by-category-over-time"></canvas>
-    </div>
-    {{ spend_by_category_over_time_json|json_script:"spend-by-category-over-time" }}
-  </section>
-{% endif %}
+{% extends "finance/dashboards/_section.html" %}
+
+{% block body %}
+  <div class="mt-4 h-72">
+    <canvas data-chart="lines" data-source="spend-by-category-over-time"></canvas>
+  </div>
+  {{ spend_by_category_over_time_json|json_script:"spend-by-category-over-time" }}
+{% endblock %}

--- a/finance/templates/finance/dashboards/sections/spend_over_time.html
+++ b/finance/templates/finance/dashboards/sections/spend_over_time.html
@@ -1,31 +1,34 @@
+{% extends "finance/dashboards/_section.html" %}
 {% load finance_extras %}
-{% if spend_has_data %}
-  <p class="mt-2 font-mono text-3xl font-bold">${{ spend_total|money:0 }}</p>
+
+{% block controls %}
+  <select data-chart-mode="spend-over-time"
+          class="rounded-button border border-border bg-background px-2 py-1.5 text-xs text-text-primary focus:outline-none focus:ring-2 focus:ring-primary">
+    <option value="">Combined</option>
+    <option value="category">By category</option>
+    {% for category_id, category_name in spend_subcategory_options %}
+      <option value="sub:{{ category_id }}">{{ category_name }}, by subcategory</option>
+    {% endfor %}
+  </select>
+{% endblock %}
+
+{% block body %}
+  {% comment %}
+    The window's headline figure. It used to sit above this card as loose
+    page-level text, which read as "the total for the page" — wrong, since
+    sections are reorderable and this one is not always first. It belongs to
+    this section, so it lives in it.
+  {% endcomment %}
+  <p class="mt-3 font-mono text-3xl font-bold">${{ spend_total|money:0 }}</p>
   <p class="text-xs text-text-muted">total spend this window</p>
 
-  <section class="mt-6 rounded-card border border-border bg-surface p-5">
-    <div class="flex flex-wrap items-center justify-between gap-3">
-      <h2 class="text-sm font-semibold uppercase tracking-wide text-text-muted">Spend over time</h2>
-      <div class="flex items-center gap-3">
-        <select data-chart-mode="spend-over-time"
-                class="rounded-button border border-border bg-background px-2 py-1.5 text-xs text-text-primary focus:outline-none focus:ring-2 focus:ring-primary">
-          <option value="">Combined</option>
-          <option value="category">By category</option>
-          {% for category_id, category_name in spend_subcategory_options %}
-            <option value="sub:{{ category_id }}">{{ category_name }}, by subcategory</option>
-          {% endfor %}
-        </select>
-        {% include "finance/dashboards/_hide_chart_button.html" %}
-      </div>
-    </div>
-    <div class="mt-4 h-64">
-      <canvas data-chart="bar" data-mode-select="spend-over-time"
-              data-source="spend-over-time" data-source-stacked="spend-over-time-by-category"
-              data-source-subcategory="spend-over-time-by-subcategory"
-              data-label="Spend"></canvas>
-    </div>
-    {{ spend_over_time_json|json_script:"spend-over-time" }}
-    {{ spend_by_category_over_time_json|json_script:"spend-over-time-by-category" }}
-    {{ spend_by_subcategory_over_time_json|json_script:"spend-over-time-by-subcategory" }}
-  </section>
-{% endif %}
+  <div class="mt-4 h-64">
+    <canvas data-chart="bar" data-mode-select="spend-over-time"
+            data-source="spend-over-time" data-source-stacked="spend-over-time-by-category"
+            data-source-subcategory="spend-over-time-by-subcategory"
+            data-label="Spend"></canvas>
+  </div>
+  {{ spend_over_time_json|json_script:"spend-over-time" }}
+  {{ spend_by_category_over_time_json|json_script:"spend-over-time-by-category" }}
+  {{ spend_by_subcategory_over_time_json|json_script:"spend-over-time-by-subcategory" }}
+{% endblock %}

--- a/finance/tests/test_dashboards.py
+++ b/finance/tests/test_dashboards.py
@@ -911,7 +911,8 @@ class ChartHideShowTests(AnalyticsTestCase):
         response = self.client.get(reverse("finance:charts"))
 
         self.assertIn(
-            "spend_over_time", dict(response.context["hidden_sections"])
+            "spend_over_time",
+            [section.slug for section in response.context["hidden_sections"]],
         )
         self.assertContains(response, "Hidden charts")
 
@@ -959,6 +960,76 @@ class ChartHideShowTests(AnalyticsTestCase):
         )
 
         self.assertRedirects(response, f"{reverse('finance:charts')}?range=3m")
+
+
+class ChartSectionLayoutTests(AnalyticsTestCase):
+    """The card scaffold every section shares, and who owns the spacing."""
+
+    def setUp(self):
+        super().setUp()
+        self.sign_in()
+        make_transaction(
+            self.checking, posted_on=household_today(), amount=Decimal("-100.00"),
+            description_raw="MARIANOS", category=self.groceries,
+        )
+
+    def test_sections_declare_no_margin_of_their_own(self):
+        """Sections are reorderable, so a margin declared on a section makes
+        the gap above a card depend on which card it happens to be. The
+        container owns the rhythm instead."""
+        from pathlib import Path
+
+        sections = Path("finance/templates/finance/dashboards/sections")
+
+        for path in sorted(sections.glob("*.html")):
+            body = path.read_text()
+            first_line = body.split("\n", 1)[0]
+            self.assertIn(
+                "_section.html", first_line,
+                f"{path.name} should extend the shared section card",
+            )
+            self.assertNotIn(
+                '<section class="mt-', body,
+                f"{path.name} declares its own top margin",
+            )
+
+    def test_the_container_owns_the_spacing_between_sections(self):
+        response = self.client.get(reverse("finance:charts"))
+
+        self.assertContains(response, 'class="mt-8 space-y-8"')
+
+    def test_visible_sections_carries_the_label_and_blurb(self):
+        response = self.client.get(reverse("finance:charts"))
+        sections = response.context["visible_sections"]
+
+        self.assertTrue(sections)
+        spend = next(s for s in sections if s.slug == "spend_over_time")
+        self.assertEqual(spend.label, "Spend over time")
+        self.assertTrue(spend.blurb)
+        self.assertContains(response, spend.blurb[:40])
+
+    def test_a_section_without_data_is_not_in_visible_sections(self):
+        response = self.client.get(reverse("finance:charts"))
+        slugs = [s.slug for s in response.context["visible_sections"]]
+
+        # No balance snapshots exist in this fixture, so the balances chart
+        # has nothing to draw and must not reach the template at all.
+        self.assertNotIn("balances_over_time", slugs)
+
+    def test_the_spend_total_lives_inside_its_own_section(self):
+        """It used to sit above the card as page-level text, which read as a
+        total for the whole page — wrong once sections can be reordered."""
+        from pathlib import Path
+
+        body = Path(
+            "finance/templates/finance/dashboards/sections/spend_over_time.html"
+        ).read_text()
+
+        self.assertIn("total spend this window", body)
+        self.assertIn("{% block body %}", body)
+        self.assertLess(
+            body.index("{% block body %}"), body.index("total spend this window")
+        )
 
 
 class BalancesOverTimeFilterTests(AnalyticsTestCase):

--- a/finance/views/dashboards.py
+++ b/finance/views/dashboards.py
@@ -26,7 +26,7 @@ from urllib.parse import urlencode
 from django.shortcuts import redirect
 from django.urls import reverse
 
-from ..chart_sections import CHART_SECTION_CHOICES
+from ..chart_sections import CHART_SECTIONS, CHART_SECTIONS_BY_SLUG
 from ..dates import household_today
 from ..models import (
     Account,
@@ -165,12 +165,12 @@ class ChartsView(FinanceView):
         return max(1, page)
 
     def known_sections(self):
-        return {slug for slug, _ in CHART_SECTION_CHOICES}
+        return set(CHART_SECTIONS_BY_SLUG)
 
     def effective_chart_sections(self):
         """The person's chosen sections, filtered to ones that still exist —
-        a section retired from CHART_SECTION_CHOICES should not linger in a
-        saved preference forever."""
+        a section retired from CHART_SECTIONS should not linger in a saved
+        preference forever."""
         known = self.known_sections()
         return [slug for slug in self.get_preference().chart_section_order if slug in known]
 
@@ -213,9 +213,9 @@ class ChartsView(FinanceView):
 
         chart_sections = self.effective_chart_sections()
         hidden_sections = [
-            (slug, label)
-            for slug, label in CHART_SECTION_CHOICES
-            if slug not in chart_sections
+            section
+            for section in CHART_SECTIONS
+            if section.slug not in chart_sections
         ]
 
         context.update(
@@ -258,16 +258,16 @@ class ChartsView(FinanceView):
             "balances_over_time": context["balances_over_time_available"],
         }
 
-        context["has_any_data"] = any(
-            [
-                context["spend_has_data"],
-                context["income_has_data"],
-                context["cash_flow_has_data"],
-                context["large_transactions_available"],
-                context["net_worth_has_data"],
-                context["balances_over_time_available"],
-            ]
-        )
+        # The sections this person has chosen, in their order, filtered to the
+        # ones with something to show — resolved here rather than re-tested in
+        # each section template, which was a second copy of the same condition.
+        context["visible_sections"] = [
+            CHART_SECTIONS_BY_SLUG[slug]
+            for slug in chart_sections
+            if context["section_has_data"].get(slug)
+        ]
+
+        context["has_any_data"] = any(context["section_has_data"].values())
 
         return context
 

--- a/static/css/tailwind.css
+++ b/static/css/tailwind.css
@@ -554,6 +554,40 @@ video {
   display: none;
 }
 
+.container {
+  width: 100%;
+}
+
+@media (min-width: 640px) {
+  .container {
+    max-width: 640px;
+  }
+}
+
+@media (min-width: 768px) {
+  .container {
+    max-width: 768px;
+  }
+}
+
+@media (min-width: 1024px) {
+  .container {
+    max-width: 1024px;
+  }
+}
+
+@media (min-width: 1280px) {
+  .container {
+    max-width: 1280px;
+  }
+}
+
+@media (min-width: 1536px) {
+  .container {
+    max-width: 1536px;
+  }
+}
+
 .prose {
   color: var(--tw-prose-body);
   max-width: 65ch;
@@ -1767,6 +1801,10 @@ video {
   background-color: rgb(11 15 25 / var(--tw-bg-opacity, 1));
 }
 
+.bg-background\/60 {
+  background-color: rgb(11 15 25 / 0.6);
+}
+
 .bg-background\/95 {
   background-color: rgb(11 15 25 / 0.95);
 }
@@ -2007,6 +2045,10 @@ video {
 
 .pt-4 {
   padding-top: 1rem;
+}
+
+.pt-5 {
+  padding-top: 1.25rem;
 }
 
 .text-left {


### PR DESCRIPTION
Stacked on [#67](https://github.com/dimays/datamays/pull/67) — review that first.

## The change

All nine Charts-tab sections repeated the same scaffold: the card, the header row, the title, the blurb, the Hide chart button. That is how they drifted into **two different header layouts** and **four different top margins**.

They now extend `dashboards/_section.html` and supply only what is theirs:

```
{% extends "finance/dashboards/_section.html" %}
{% block controls %}…optional, sits left of Hide chart…{% endblock %}
{% block body %}…the chart…{% endblock %}
```

Title and blurb move into `finance/chart_sections.py` next to the slug, so retitling a section is a one-line edit rather than a hunt through nine near-identical partials.

## Two pieces of duplicated logic removed

**The redundant guard.** Every section opened with `{% if spend_has_data %}` (or equivalent) — the *same flag* `charts.html` had just tested to decide whether to include it at all. The view now hands over `visible_sections`, already filtered.

**The spacing.** Sections are user-reorderable, so a margin declared on a section makes the gap depend on which card it happens to be. The container owns it now (`space-y-8`).

I measured this before claiming it, and the result is narrower than I first thought — worth being precise:

| Section's own margin | Gap it actually produced |
|---|---|
| none | 32px |
| `mt-4` | 32px |
| `mt-8` | 32px |
| `mt-6` **+ leading paragraphs** (Spend over time) | **96px** |

Margin collapsing was absorbing the difference for eight of the nine — the wrapper's `mt-8` won and the margins were effectively dead code. Spend over time was the real one: its loose "total spend" paragraphs broke the collapse, leaving a 96px gap where every other card had 32px. Measured after the change: **first section 0, every other section exactly 32px.**

## Small redesign

That total-spend figure moves inside the card. As page-level text floating above it, it read as a total for the *whole page* — wrong for a section that can be dragged anywhere in the order. Payslip detail is likewise nested inside Net income rather than trailing it as two loose sibling cards that would separate from the figure they explain on reorder.

## Test plan
- [x] `manage.py test finance` — 612 passed (607 + 5 new)
- [x] New `ChartSectionLayoutTests` covers: no section declares its own margin, the container owns spacing, `visible_sections` carries label/blurb, a section without data never reaches the template, and the total lives inside its section
- [x] Browser: all 9 sections render, gaps uniform at 32px, all 15 Chart.js instances built with data, no console errors
- [x] `npm run tailwind:build` committed