### PR TITLE
Name the three repeated UI patterns, and fix the native controls

### DIFF
--- a/assets/css/input.css
+++ b/assets/css/input.css
@@ -2,7 +2,49 @@
 @tailwind components;
 @tailwind utilities;
 
-/* Keeps Alpine-controlled elements hidden until Alpine initialises them,
+@layer base {
+  /* Tells the browser this is a dark UI, so the controls it draws itself —
+     select dropdown panels, scrollbars, date pickers — come out dark too.
+     Without it a <select> opens a white panel on top of a near-black page,
+     which is the single most obvious "unfinished" tell on a dark theme. */
+  :root {
+    color-scheme: dark;
+  }
+
+  /* Native checkboxes ignore Tailwind's text-* colour, so every checkbox in
+     the app was rendering in the browser's default blue against an indigo
+     and teal palette. accent-color is the one property that actually
+     recolours them, and costs nothing next to pulling in a forms plugin. */
+  input[type="checkbox"],
+  input[type="radio"] {
+    accent-color: theme("colors.primary.DEFAULT");
+  }
+}
+
+@layer components {
+  /* Three patterns that were being retyped rather than reused. Each existed
+     in more than one variant purely by drift — the empty state in two
+     paddings, the page title in twenty copies of one class string — so
+     naming them is both less typing and the thing that keeps them uniform. */
+
+  .page-title {
+    @apply text-2xl font-extrabold tracking-tight md:text-3xl;
+  }
+
+  /* The line under a page's h1. max-width is part of it: these ran to the
+     full width of the page on some screens and were capped at max-w-2xl or
+     max-w-lg on others, purely by whoever wrote them. A measure that stays
+     readable is the right default, and a short subtitle never reaches it. */
+  .page-subtitle {
+    @apply mt-2 max-w-2xl text-text-secondary;
+  }
+
+  .empty-state {
+    @apply rounded-card border border-dashed border-border bg-surface/50 p-8 text-center;
+  }
+}
+
+/* Keeps Alpine-controlled elements hidden until Alpine initializes them,
    so dropdowns don't flash open on first paint. */
 [x-cloak] {
   display: none !important;

--- a/assets/css/input.css
+++ b/assets/css/input.css
@@ -11,10 +11,10 @@
     color-scheme: dark;
   }
 
-  /* Native checkboxes ignore Tailwind's text-* colour, so every checkbox in
+  /* Native checkboxes ignore Tailwind's text-* color, so every checkbox in
      the app was rendering in the browser's default blue against an indigo
      and teal palette. accent-color is the one property that actually
-     recolours them, and costs nothing next to pulling in a forms plugin. */
+     recolors them, and costs nothing next to pulling in a forms plugin. */
   input[type="checkbox"],
   input[type="radio"] {
     accent-color: theme("colors.primary.DEFAULT");

--- a/finance/templates/finance/alerts/confirm_delete.html
+++ b/finance/templates/finance/alerts/confirm_delete.html
@@ -1,7 +1,7 @@
 {% extends "finance/base_finance.html" %}
 
 {% block finance_content %}
-<h1 class="text-2xl font-extrabold tracking-tight md:text-3xl">Delete alert</h1>
+<h1 class="page-title">Delete alert</h1>
 
 <div class="mt-6 max-w-lg rounded-card border border-error/40 bg-error/5 p-6">
   <p class="text-text-secondary">Delete <span class="font-semibold text-text-primary">{{ alert.name }}</span>?</p>

--- a/finance/templates/finance/alerts/form.html
+++ b/finance/templates/finance/alerts/form.html
@@ -1,7 +1,7 @@
 {% extends "finance/base_finance.html" %}
 
 {% block finance_content %}
-<h1 class="text-2xl font-extrabold tracking-tight md:text-3xl">{{ page_title }}</h1>
+<h1 class="page-title">{{ page_title }}</h1>
 
 {% include "finance/partials/messages.html" %}
 

--- a/finance/templates/finance/alerts/list.html
+++ b/finance/templates/finance/alerts/list.html
@@ -2,8 +2,8 @@
 {% load finance_extras %}
 
 {% block finance_content %}
-<h1 class="text-2xl font-extrabold tracking-tight md:text-3xl">Alerts &amp; reports</h1>
-<p class="mt-2 text-text-secondary">Yours alone — {{ request.user.first_name|default:request.user.username }}'s thresholds, to your inbox.</p>
+<h1 class="page-title">Alerts &amp; reports</h1>
+<p class="page-subtitle">Yours alone — {{ request.user.first_name|default:request.user.username }}'s thresholds, to your inbox.</p>
 
 {% include "finance/partials/messages.html" %}
 
@@ -34,7 +34,7 @@
         </div>
       </a>
     {% empty %}
-      <div class="rounded-card border border-dashed border-border bg-surface/50 p-6 text-center">
+      <div class="empty-state">
         <p class="text-sm text-text-secondary">No alerts yet.</p>
       </div>
     {% endfor %}
@@ -59,7 +59,7 @@
         </p>
       </a>
     {% empty %}
-      <div class="rounded-card border border-dashed border-border bg-surface/50 p-6 text-center">
+      <div class="empty-state">
         <p class="text-sm text-text-secondary">No reports scheduled.</p>
       </div>
     {% endfor %}

--- a/finance/templates/finance/alerts/report_form.html
+++ b/finance/templates/finance/alerts/report_form.html
@@ -1,7 +1,7 @@
 {% extends "finance/base_finance.html" %}
 
 {% block finance_content %}
-<h1 class="text-2xl font-extrabold tracking-tight md:text-3xl">{{ page_title }}</h1>
+<h1 class="page-title">{{ page_title }}</h1>
 
 {% include "finance/partials/messages.html" %}
 

--- a/finance/templates/finance/budgets/confirm_delete.html
+++ b/finance/templates/finance/budgets/confirm_delete.html
@@ -1,7 +1,7 @@
 {% extends "finance/base_finance.html" %}
 
 {% block finance_content %}
-<h1 class="text-2xl font-extrabold tracking-tight md:text-3xl">Delete budget</h1>
+<h1 class="page-title">Delete budget</h1>
 
 <div class="mt-6 max-w-lg rounded-card border border-error/40 bg-error/5 p-6">
   <p class="text-text-secondary">

--- a/finance/templates/finance/budgets/form.html
+++ b/finance/templates/finance/budgets/form.html
@@ -1,7 +1,7 @@
 {% extends "finance/base_finance.html" %}
 
 {% block finance_content %}
-<h1 class="text-2xl font-extrabold tracking-tight md:text-3xl">{{ page_title }}</h1>
+<h1 class="page-title">{{ page_title }}</h1>
 
 {% include "finance/partials/messages.html" %}
 

--- a/finance/templates/finance/budgets/list.html
+++ b/finance/templates/finance/budgets/list.html
@@ -3,7 +3,7 @@
 
 {% block finance_content %}
 <div class="flex flex-wrap items-center justify-between gap-3">
-  <h1 class="text-2xl font-extrabold tracking-tight md:text-3xl">Budgets</h1>
+  <h1 class="page-title">Budgets</h1>
   <a href="{% url 'finance:budget_create' %}"
      class="rounded-button bg-primary px-4 py-2.5 text-sm font-medium text-white transition hover:bg-primary-600">
     New budget
@@ -59,7 +59,7 @@
       {% endif %}
     </div>
   {% empty %}
-    <div class="rounded-card border border-dashed border-border bg-surface/50 p-8 text-center">
+    <div class="empty-state">
       <p class="text-text-secondary">No budgets yet.</p>
       <a href="{% url 'finance:budget_create' %}" class="mt-2 inline-block text-primary hover:underline">
         Create the first one →

--- a/finance/templates/finance/dashboards/charts.html
+++ b/finance/templates/finance/dashboards/charts.html
@@ -2,12 +2,12 @@
 {% load finance_extras static %}
 
 {% block finance_content %}
-<h1 class="text-2xl font-extrabold tracking-tight md:text-3xl">Charts</h1>
+<h1 class="page-title">Charts</h1>
 
 {% include "finance/dashboards/_filters.html" with show_grain=1 %}
 
 {% if not has_any_data %}
-  <div class="mt-8 rounded-card border border-dashed border-border bg-surface/50 p-8 text-center">
+  <div class="mt-8 empty-state">
     <p class="text-text-secondary">Nothing to chart in this window yet.</p>
   </div>
 {% else %}

--- a/finance/templates/finance/help.html
+++ b/finance/templates/finance/help.html
@@ -1,8 +1,8 @@
 {% extends "finance/base_finance.html" %}
 
 {% block finance_content %}
-<h1 class="text-2xl font-extrabold tracking-tight md:text-3xl">Help</h1>
-<p class="mt-2 max-w-2xl text-text-secondary">
+<h1 class="page-title">Help</h1>
+<p class="page-subtitle">
   What each screen does, in one place. For anything about how the app is
   wired up behind the scenes — connecting accounts, scheduling, backups —
   see the runbook in the repo.

--- a/finance/templates/finance/home.html
+++ b/finance/templates/finance/home.html
@@ -2,7 +2,7 @@
 
 {% block finance_content %}
 <div class="flex flex-wrap items-center justify-between gap-3">
-  <h1 class="text-2xl font-extrabold tracking-tight md:text-3xl">
+  <h1 class="page-title">
     {% if request.user.first_name %}Hi, {{ request.user.first_name }}{% else %}Home{% endif %}
   </h1>
   <a href="{% url 'finance:preferences' %}" class="text-sm text-text-muted transition hover:text-text-secondary">
@@ -16,7 +16,7 @@
   {% for widget in widgets %}
     {% include "finance/widgets/"|add:widget.slug|add:".html" with data=widget.data label=widget.label %}
   {% empty %}
-    <div class="rounded-card border border-dashed border-border bg-surface/50 p-8 text-center">
+    <div class="empty-state">
       <p class="text-text-secondary">No widgets selected.</p>
       <a href="{% url 'finance:preferences' %}" class="mt-2 inline-block text-primary hover:underline">
         Choose what to show →

--- a/finance/templates/finance/imports/list.html
+++ b/finance/templates/finance/imports/list.html
@@ -2,7 +2,7 @@
 
 {% block finance_content %}
 <div class="flex flex-wrap items-center justify-between gap-4">
-  <h1 class="text-2xl font-extrabold tracking-tight md:text-3xl">Imports</h1>
+  <h1 class="page-title">Imports</h1>
   <div class="flex gap-2">
     <a href="{% url 'finance:import_schemas' %}"
        class="rounded-button border border-border bg-surface px-4 py-2.5 text-sm font-medium transition hover:bg-muted">
@@ -15,7 +15,7 @@
   </div>
 </div>
 
-<p class="mt-2 max-w-2xl text-text-secondary">
+<p class="page-subtitle">
   For the accounts nobody can sync automatically — the life policy, the
   mortgage, and payslips. Not sure what a file needs to include? See the
   <a href="{% url 'finance:import_schemas' %}" class="text-primary hover:underline">field reference</a>.
@@ -53,7 +53,7 @@
       </div>
     </div>
   {% empty %}
-    <div class="rounded-card border border-dashed border-border bg-surface/50 p-8 text-center">
+    <div class="empty-state">
       <p class="text-text-secondary">No files imported yet.</p>
     </div>
   {% endfor %}

--- a/finance/templates/finance/imports/map.html
+++ b/finance/templates/finance/imports/map.html
@@ -2,8 +2,8 @@
 {% load finance_extras %}
 
 {% block finance_content %}
-<h1 class="text-2xl font-extrabold tracking-tight md:text-3xl">Confirm columns</h1>
-<p class="mt-2 max-w-2xl text-text-secondary">
+<h1 class="page-title">Confirm columns</h1>
+<p class="page-subtitle">
   Here's what <span class="font-medium text-text-primary">{{ batch.original_filename }}</span>
   looks like it contains. Anything marked <span class="text-warning">unsure</span> is worth a
   second look — a wrong column lands plausible numbers in the wrong place.

--- a/finance/templates/finance/imports/preview.html
+++ b/finance/templates/finance/imports/preview.html
@@ -1,8 +1,8 @@
 {% extends "finance/base_finance.html" %}
 
 {% block finance_content %}
-<h1 class="text-2xl font-extrabold tracking-tight md:text-3xl">Review import</h1>
-<p class="mt-2 max-w-2xl text-text-secondary">
+<h1 class="page-title">Review import</h1>
+<p class="page-subtitle">
   Nothing has been saved yet. Check that the amounts and dates look right,
   then commit.
 </p>

--- a/finance/templates/finance/imports/schemas.html
+++ b/finance/templates/finance/imports/schemas.html
@@ -2,11 +2,11 @@
 
 {% block finance_content %}
 <div class="flex flex-wrap items-center justify-between gap-3">
-  <h1 class="text-2xl font-extrabold tracking-tight md:text-3xl">Import schemas</h1>
+  <h1 class="page-title">Import schemas</h1>
   <a href="{% url 'finance:imports' %}" class="text-sm text-primary hover:underline">← Imports</a>
 </div>
 
-<p class="mt-2 max-w-2xl text-text-secondary">
+<p class="page-subtitle">
   What each record type needs before a file can be mapped and committed. This
   is reference only, not a form — the shape of each record type is fixed in
   the importer itself, so it can't be edited here. Column <em>names</em> in

--- a/finance/templates/finance/imports/upload.html
+++ b/finance/templates/finance/imports/upload.html
@@ -1,8 +1,8 @@
 {% extends "finance/base_finance.html" %}
 
 {% block finance_content %}
-<h1 class="text-2xl font-extrabold tracking-tight md:text-3xl">Import a file</h1>
-<p class="mt-2 max-w-2xl text-text-secondary">
+<h1 class="page-title">Import a file</h1>
+<p class="page-subtitle">
   Upload a CSV export. The next screen shows which column it thinks is which,
   for you to confirm before anything is saved.
 </p>

--- a/finance/templates/finance/qfr/detail.html
+++ b/finance/templates/finance/qfr/detail.html
@@ -3,7 +3,7 @@
 
 {% block finance_content %}
 <div class="flex flex-wrap items-baseline justify-between gap-3">
-  <h1 class="text-2xl font-extrabold tracking-tight md:text-3xl">{{ report.label }}</h1>
+  <h1 class="page-title">{{ report.label }}</h1>
   <p class="text-sm text-text-muted">{{ report.period_start|date:"j M Y" }} – {{ report.period_end|date:"j M Y" }}</p>
 </div>
 

--- a/finance/templates/finance/qfr/list.html
+++ b/finance/templates/finance/qfr/list.html
@@ -4,8 +4,8 @@
 {% block finance_content %}
 <div class="flex flex-wrap items-start justify-between gap-4">
   <div>
-    <h1 class="text-2xl font-extrabold tracking-tight md:text-3xl">Quarterly Finance Reports</h1>
-    <p class="mt-2 max-w-2xl text-text-secondary">
+    <h1 class="page-title">Quarterly Finance Reports</h1>
+    <p class="page-subtitle">
       A snapshot of each closed quarter — generated once it ends, not live.
     </p>
   </div>
@@ -52,7 +52,7 @@
       </p>
     </a>
   {% empty %}
-    <div class="rounded-card border border-dashed border-border bg-surface/50 p-8 text-center">
+    <div class="empty-state">
       <p class="text-text-secondary">No reports generated yet.</p>
       {% if not available_quarters %}
         <p class="mt-2 text-xs text-text-muted">

--- a/finance/templates/finance/settings/account_form.html
+++ b/finance/templates/finance/settings/account_form.html
@@ -1,7 +1,7 @@
 {% extends "finance/base_finance.html" %}
 
 {% block finance_content %}
-<h1 class="text-2xl font-extrabold tracking-tight md:text-3xl">{{ page_title }}</h1>
+<h1 class="page-title">{{ page_title }}</h1>
 
 {% include "finance/partials/messages.html" %}
 

--- a/finance/templates/finance/settings/categories.html
+++ b/finance/templates/finance/settings/categories.html
@@ -2,13 +2,13 @@
 
 {% block finance_content %}
 <div class="flex flex-wrap items-center justify-between gap-3">
-  <h1 class="text-2xl font-extrabold tracking-tight md:text-3xl">Categories</h1>
+  <h1 class="page-title">Categories</h1>
   <a href="{% url 'finance:category_create' %}"
      class="rounded-button bg-primary px-3.5 py-2 text-xs font-medium text-white transition hover:bg-primary-600">
     Add category
   </a>
 </div>
-<p class="mt-2 max-w-2xl text-text-secondary">
+<p class="page-subtitle">
   Archiving keeps a category selectable on existing transactions — it just
   moves to its own section at the bottom of the category picker, so old data
   stays readable without cluttering the choices for new ones. Deleting asks
@@ -60,7 +60,7 @@
       </div>
     </div>
   {% empty %}
-    <div class="rounded-card border border-dashed border-border bg-surface/50 p-8 text-center">
+    <div class="empty-state">
       <p class="text-text-secondary">No categories yet.</p>
     </div>
   {% endfor %}

--- a/finance/templates/finance/settings/category_delete.html
+++ b/finance/templates/finance/settings/category_delete.html
@@ -1,7 +1,7 @@
 {% extends "finance/base_finance.html" %}
 
 {% block finance_content %}
-<h1 class="text-2xl font-extrabold tracking-tight md:text-3xl">Delete {{ category.full_path }}</h1>
+<h1 class="page-title">Delete {{ category.full_path }}</h1>
 
 {% include "finance/partials/messages.html" %}
 

--- a/finance/templates/finance/settings/category_form.html
+++ b/finance/templates/finance/settings/category_form.html
@@ -1,7 +1,7 @@
 {% extends "finance/base_finance.html" %}
 
 {% block finance_content %}
-<h1 class="text-2xl font-extrabold tracking-tight md:text-3xl">{{ page_title }}</h1>
+<h1 class="page-title">{{ page_title }}</h1>
 
 {% include "finance/partials/messages.html" %}
 

--- a/finance/templates/finance/settings/connection_detail.html
+++ b/finance/templates/finance/settings/connection_detail.html
@@ -2,8 +2,8 @@
 {% load finance_extras %}
 
 {% block finance_content %}
-<h1 class="text-2xl font-extrabold tracking-tight md:text-3xl">{{ connection.label }}</h1>
-<p class="mt-2 text-text-secondary">{{ connection.get_provider_display }}</p>
+<h1 class="page-title">{{ connection.label }}</h1>
+<p class="page-subtitle">{{ connection.get_provider_display }}</p>
 
 {% include "finance/partials/messages.html" %}
 

--- a/finance/templates/finance/settings/connection_form.html
+++ b/finance/templates/finance/settings/connection_form.html
@@ -1,7 +1,7 @@
 {% extends "finance/base_finance.html" %}
 
 {% block finance_content %}
-<h1 class="text-2xl font-extrabold tracking-tight md:text-3xl">Connect an institution</h1>
+<h1 class="page-title">Connect an institution</h1>
 
 <ol class="mt-6 max-w-2xl space-y-2 text-sm text-text-secondary">
   <li>1. Go to <span class="font-mono text-xs text-text-primary">bridge.simplefin.org</span> and authorize one or more institutions — SimpleFIN lets you link several to a single setup token, and this form doesn't need you to say which up front.</li>

--- a/finance/templates/finance/settings/index.html
+++ b/finance/templates/finance/settings/index.html
@@ -2,8 +2,8 @@
 {% load finance_extras %}
 
 {% block finance_content %}
-<h1 class="text-2xl font-extrabold tracking-tight md:text-3xl">Settings</h1>
-<p class="mt-2 text-text-secondary">Shared by the household — changes here affect what both of you see.</p>
+<h1 class="page-title">Settings</h1>
+<p class="page-subtitle">Shared by the household — changes here affect what both of you see.</p>
 
 {% include "finance/partials/messages.html" %}
 
@@ -54,7 +54,7 @@
         </div>
       </a>
     {% empty %}
-      <div class="rounded-card border border-dashed border-border bg-surface/50 p-6 text-center">
+      <div class="empty-state">
         <p class="text-sm text-text-secondary">No institutions connected yet.</p>
       </div>
     {% endfor %}

--- a/finance/templates/finance/settings/institution_form.html
+++ b/finance/templates/finance/settings/institution_form.html
@@ -1,7 +1,7 @@
 {% extends "finance/base_finance.html" %}
 
 {% block finance_content %}
-<h1 class="text-2xl font-extrabold tracking-tight md:text-3xl">{{ page_title }}</h1>
+<h1 class="page-title">{{ page_title }}</h1>
 
 {% include "finance/partials/messages.html" %}
 

--- a/finance/templates/finance/settings/institutions.html
+++ b/finance/templates/finance/settings/institutions.html
@@ -2,13 +2,13 @@
 
 {% block finance_content %}
 <div class="flex flex-wrap items-center justify-between gap-3">
-  <h1 class="text-2xl font-extrabold tracking-tight md:text-3xl">Institutions</h1>
+  <h1 class="page-title">Institutions</h1>
   <a href="{% url 'finance:institution_create' %}"
      class="rounded-button bg-primary px-4 py-2.5 text-sm font-medium text-white transition hover:bg-primary-600">
     New institution
   </a>
 </div>
-<p class="mt-2 text-text-secondary">
+<p class="page-subtitle">
   Every account attaches to one of these — including the ones no automated
   connector can reach, which just need an institution here before you can
   add a manual account or import a statement for them.
@@ -35,7 +35,7 @@
       </div>
     </a>
   {% empty %}
-    <div class="rounded-card border border-dashed border-border bg-surface/50 p-8 text-center">
+    <div class="empty-state">
       <p class="text-text-secondary">No institutions yet.</p>
       <a href="{% url 'finance:institution_create' %}" class="mt-2 inline-block text-primary hover:underline">
         Add the first one →

--- a/finance/templates/finance/settings/preferences.html
+++ b/finance/templates/finance/settings/preferences.html
@@ -2,8 +2,8 @@
 {% load static %}
 
 {% block finance_content %}
-<h1 class="text-2xl font-extrabold tracking-tight md:text-3xl">Preferences</h1>
-<p class="mt-2 text-text-secondary">Just for you — {{ request.user.first_name|default:request.user.username }}. These don't change what anyone else sees.</p>
+<h1 class="page-title">Preferences</h1>
+<p class="page-subtitle">Just for you — {{ request.user.first_name|default:request.user.username }}. These don't change what anyone else sees.</p>
 
 {% include "finance/partials/messages.html" %}
 

--- a/finance/templates/finance/settings/rule_form.html
+++ b/finance/templates/finance/settings/rule_form.html
@@ -1,8 +1,8 @@
 {% extends "finance/base_finance.html" %}
 
 {% block finance_content %}
-<h1 class="text-2xl font-extrabold tracking-tight md:text-3xl">{{ page_title }}</h1>
-<p class="mt-2 max-w-lg text-text-secondary">
+<h1 class="page-title">{{ page_title }}</h1>
+<p class="page-subtitle">
   Rules run before the classifier and always win, so use them for anything
   you want categorized the same way every time — an exact match is unlikely
   for most bank descriptions, so "Contains" is usually the right choice.

--- a/finance/templates/finance/settings/rules.html
+++ b/finance/templates/finance/settings/rules.html
@@ -2,13 +2,13 @@
 
 {% block finance_content %}
 <div class="flex flex-wrap items-center justify-between gap-3">
-  <h1 class="text-2xl font-extrabold tracking-tight md:text-3xl">Category rules</h1>
+  <h1 class="page-title">Category rules</h1>
   <a href="{% url 'finance:rule_create' %}"
      class="rounded-button bg-primary px-3.5 py-2 text-xs font-medium text-white transition hover:bg-primary-600">
     Add rule
   </a>
 </div>
-<p class="mt-2 max-w-2xl text-text-secondary">
+<p class="page-subtitle">
   Rules run before the classifier and always win — a merchant matching one
   never reaches review at all. Contains, starts-with, exact, or a regular
   expression, optionally scoped to one account or an amount range.
@@ -49,7 +49,7 @@
       </div>
     </div>
   {% empty %}
-    <div class="rounded-card border border-dashed border-border bg-surface/50 p-8 text-center">
+    <div class="empty-state">
       <p class="text-text-secondary">No rules yet — the classifier is handling everything.</p>
     </div>
   {% endfor %}

--- a/finance/templates/finance/transactions/list.html
+++ b/finance/templates/finance/transactions/list.html
@@ -3,7 +3,7 @@
 
 {% block finance_content %}
 <div class="flex flex-wrap items-center justify-between gap-3">
-  <h1 class="text-2xl font-extrabold tracking-tight md:text-3xl">Activity</h1>
+  <h1 class="page-title">Activity</h1>
 
   {% if review_count %}
     <a href="?review=1"
@@ -238,7 +238,7 @@
         </div>
       </div>
     {% empty %}
-      <div class="rounded-card border border-dashed border-border bg-surface/50 p-8 text-center">
+      <div class="empty-state">
         <p class="text-text-secondary">
           {% if review_only %}
             Nothing left to review.

--- a/finance/tests/test_spelling.py
+++ b/finance/tests/test_spelling.py
@@ -20,10 +20,21 @@ REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 # Directories whose contents this repo does not author.
 EXCLUDED_DIRS = {
     ".git", ".venv", "node_modules", "staticfiles", "__pycache__",
-    "migrations", ".devcontainer", "assets",
+    "migrations", ".devcontainer",
 }
 
-CHECKED_SUFFIXES = {".py", ".html", ".js", ".md"}
+# .css is here for assets/css/input.css, which carries real prose in its
+# comments.
+CHECKED_SUFFIXES = {".py", ".html", ".js", ".md", ".css"}
+
+# Generated or vendored, so not ours to spell. Excluded by filename rather
+# than by directory: static/js also holds finance-charts.js, which *is* ours
+# and does need checking.
+GENERATED_FILES = {"tailwind.css"}
+
+
+def _is_generated(path) -> bool:
+    return path.name in GENERATED_FILES or path.name.endswith(".min.js")
 
 # Stem → the US spelling to use instead. Matched case-insensitively as a
 # substring, so "normalis" catches normalise/normalised/normalising and
@@ -55,6 +66,8 @@ def _checked_files():
         if path.suffix not in CHECKED_SUFFIXES:
             continue
         if EXCLUDED_DIRS.intersection(path.parts):
+            continue
+        if _is_generated(path):
             continue
         yield path
 

--- a/finance/tests/test_ui_conventions.py
+++ b/finance/tests/test_ui_conventions.py
@@ -1,0 +1,81 @@
+"""The shared UI vocabulary, enforced rather than remembered.
+
+Three patterns were being retyped instead of reused, and each had drifted
+into more than one variant purely by whoever wrote it last — the empty state
+in two paddings, the page subtitle in three different max-widths, the page
+title in twenty copies of one class string.
+
+Naming them in `assets/css/input.css` fixed the drift. These tests keep it
+fixed: a template that retypes the raw utilities instead of using the
+component class will fail here rather than quietly reintroducing a variant.
+"""
+
+from pathlib import Path
+
+from django.test import SimpleTestCase
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+TEMPLATES = REPO_ROOT / "finance" / "templates"
+INPUT_CSS = REPO_ROOT / "assets" / "css" / "input.css"
+BUILT_CSS = REPO_ROOT / "static" / "css" / "tailwind.css"
+
+# Raw utility strings that now have a component class. Substring match, so a
+# template combining them with other utilities is caught too.
+RETIRED_PATTERNS = {
+    "text-2xl font-extrabold tracking-tight md:text-3xl": "page-title",
+    "border-dashed border-border bg-surface/50": "empty-state",
+}
+
+
+def _templates():
+    return sorted(TEMPLATES.rglob("*.html"))
+
+
+class ComponentClassTests(SimpleTestCase):
+    def test_no_template_retypes_a_retired_utility_string(self):
+        offenders = []
+
+        for path in _templates():
+            body = path.read_text()
+
+            for raw, replacement in RETIRED_PATTERNS.items():
+                if raw in body:
+                    offenders.append(
+                        f"{path.relative_to(REPO_ROOT)}: “{raw}” → use “{replacement}”"
+                    )
+
+        self.assertEqual(
+            offenders, [], "Use the component class:\n" + "\n".join(offenders)
+        )
+
+    def test_the_component_classes_are_defined(self):
+        source = INPUT_CSS.read_text()
+
+        for name in ("page-title", "page-subtitle", "empty-state"):
+            self.assertIn(f".{name}", source)
+
+    def test_the_committed_css_is_current(self):
+        """static/css/tailwind.css is a build artifact — Heroku runs no Node,
+        so a template change that adds a class is only live if the build was
+        re-run and committed."""
+        built = BUILT_CSS.read_text()
+
+        for name in ("page-title", "page-subtitle", "empty-state"):
+            self.assertIn(f".{name}", built, f".{name} missing — run npm run tailwind:build")
+
+
+class DarkThemeControlTests(SimpleTestCase):
+    """Native controls the browser draws itself, not Tailwind."""
+
+    def test_the_page_declares_a_dark_color_scheme(self):
+        """Without this a <select> opens a white panel over a near-black
+        page — the most obvious 'unfinished' tell on a dark theme."""
+        self.assertIn("color-scheme: dark", INPUT_CSS.read_text())
+        self.assertIn("color-scheme: dark", BUILT_CSS.read_text())
+
+    def test_checkboxes_use_the_theme_accent(self):
+        """Native checkboxes ignore Tailwind's text-* color, so every
+        checkbox rendered in the browser's default blue against an indigo
+        and teal palette. accent-color is what actually recolors them."""
+        self.assertIn("accent-color", INPUT_CSS.read_text())
+        self.assertIn("accent-color: #4F46E5", BUILT_CSS.read_text())

--- a/static/css/tailwind.css
+++ b/static/css/tailwind.css
@@ -563,10 +563,10 @@ video {
   color-scheme: dark;
 }
 
-/* Native checkboxes ignore Tailwind's text-* colour, so every checkbox in
+/* Native checkboxes ignore Tailwind's text-* color, so every checkbox in
      the app was rendering in the browser's default blue against an indigo
      and teal palette. accent-color is the one property that actually
-     recolours them, and costs nothing next to pulling in a forms plugin. */
+     recolors them, and costs nothing next to pulling in a forms plugin. */
 
 input[type="checkbox"],
   input[type="radio"] {
@@ -1827,6 +1827,10 @@ input[type="checkbox"],
   border-top-width: 1px;
 }
 
+.border-dashed {
+  border-style: dashed;
+}
+
 .border-border {
   --tw-border-opacity: 1;
   border-color: rgb(46 58 73 / var(--tw-border-opacity, 1));
@@ -1918,6 +1922,10 @@ input[type="checkbox"],
 .bg-surface {
   --tw-bg-opacity: 1;
   background-color: rgb(17 24 39 / var(--tw-bg-opacity, 1));
+}
+
+.bg-surface\/50 {
+  background-color: rgb(17 24 39 / 0.5);
 }
 
 .bg-surface\/60 {

--- a/static/css/tailwind.css
+++ b/static/css/tailwind.css
@@ -554,6 +554,25 @@ video {
   display: none;
 }
 
+/* Tells the browser this is a dark UI, so the controls it draws itself —
+     select dropdown panels, scrollbars, date pickers — come out dark too.
+     Without it a <select> opens a white panel on top of a near-black page,
+     which is the single most obvious "unfinished" tell on a dark theme. */
+
+:root {
+  color-scheme: dark;
+}
+
+/* Native checkboxes ignore Tailwind's text-* colour, so every checkbox in
+     the app was rendering in the browser's default blue against an indigo
+     and teal palette. accent-color is the one property that actually
+     recolours them, and costs nothing next to pulling in a forms plugin. */
+
+input[type="checkbox"],
+  input[type="radio"] {
+  accent-color: #4F46E5;
+}
+
 .container {
   width: 100%;
 }
@@ -1151,6 +1170,48 @@ video {
   --tw-prose-pre-bg: var(--tw-prose-invert-pre-bg);
   --tw-prose-th-borders: var(--tw-prose-invert-th-borders);
   --tw-prose-td-borders: var(--tw-prose-invert-td-borders);
+}
+
+/* Three patterns that were being retyped rather than reused. Each existed
+     in more than one variant purely by drift — the empty state in two
+     paddings, the page title in twenty copies of one class string — so
+     naming them is both less typing and the thing that keeps them uniform. */
+
+.page-title {
+  font-size: 1.5rem;
+  line-height: 2rem;
+  font-weight: 800;
+  letter-spacing: -0.025em;
+}
+
+@media (min-width: 768px) {
+  .page-title {
+    font-size: 1.875rem;
+    line-height: 2.25rem;
+  }
+}
+
+/* The line under a page's h1. max-width is part of it: these ran to the
+     full width of the page on some screens and were capped at max-w-2xl or
+     max-w-lg on others, purely by whoever wrote them. A measure that stays
+     readable is the right default, and a short subtitle never reaches it. */
+
+.page-subtitle {
+  margin-top: 0.5rem;
+  max-width: 42rem;
+  --tw-text-opacity: 1;
+  color: rgb(209 213 219 / var(--tw-text-opacity, 1));
+}
+
+.empty-state {
+  border-radius: 16px;
+  border-width: 1px;
+  border-style: dashed;
+  --tw-border-opacity: 1;
+  border-color: rgb(46 58 73 / var(--tw-border-opacity, 1));
+  background-color: rgb(17 24 39 / 0.5);
+  padding: 2rem;
+  text-align: center;
 }
 
 .sr-only {
@@ -1766,10 +1827,6 @@ video {
   border-top-width: 1px;
 }
 
-.border-dashed {
-  border-style: dashed;
-}
-
 .border-border {
   --tw-border-opacity: 1;
   border-color: rgb(46 58 73 / var(--tw-border-opacity, 1));
@@ -1863,10 +1920,6 @@ video {
   background-color: rgb(17 24 39 / var(--tw-bg-opacity, 1));
 }
 
-.bg-surface\/50 {
-  background-color: rgb(17 24 39 / 0.5);
-}
-
 .bg-surface\/60 {
   background-color: rgb(17 24 39 / 0.6);
 }
@@ -1923,10 +1976,6 @@ video {
 
 .p-6 {
   padding: 1.5rem;
-}
-
-.p-8 {
-  padding: 2rem;
 }
 
 .px-1 {
@@ -2293,7 +2342,7 @@ video {
   range_form_start: range form end;
 }
 
-/* Keeps Alpine-controlled elements hidden until Alpine initialises them,
+/* Keeps Alpine-controlled elements hidden until Alpine initializes them,
    so dropdowns don't flash open on first paint. */
 
 [x-cloak] {


### PR DESCRIPTION
Stacked on [#68](https://github.com/dimays/datamays/pull/68) — review that first.

## Three patterns that were retyped instead of reused

Each had drifted into more than one variant, purely by whoever wrote it last:

| Pattern | Was | Now |
|---|---|---|
| Page title | 20 copies of `text-2xl font-extrabold tracking-tight md:text-3xl` | `.page-title` |
| Page subtitle | 15 sites in **three** max-widths — `max-w-2xl`, `max-w-lg`, none | `.page-subtitle` |
| Empty state | 12 sites in **two** paddings — `p-6` and `p-8` | `.empty-state` |

They are `@layer components` classes in `assets/css/input.css` now. Tailwind component classes rather than Django partials on purpose: the empty states wrap genuinely different inner content (some have a call-to-action link, some a conditional message), which an `{% include %}` would have forced into a parameter list.

The subtitle's max-width is now part of the class. A readable measure is the right default and a short subtitle never reaches it — previously whether a subtitle wrapped at a sensible width was down to which template you were on.

I applied `.page-subtitle` to the 15 page-level subtitles explicitly rather than by find-and-replace: the same class string is also used for QFR narrative paragraphs and inline help text, which are body copy and keep their own styling.

## Two native-control fixes

Neither of these is something Tailwind classes can reach:

**`color-scheme: dark`** — without it a `<select>` opens a **white** dropdown panel over a near-black page. Most obvious unfinished tell on a dark theme, and it affects scrollbars and date pickers too.

**`accent-color` on checkboxes and radios** — native checkboxes ignore Tailwind's `text-*` color, so `text-primary` on every checkbox in the app was doing nothing and they all rendered in the browser's default blue against an indigo and teal palette. One property fixes it; no `@tailwindcss/forms` dependency needed.

Verified in the browser: `accentColor` computes to `rgb(79, 70, 229)` (the theme's `#4F46E5`), `colorScheme` to `dark`, subtitle `max-width` to `672px`.

## Test plan
- [x] `manage.py test finance` — 617 passed (612 + 5 new)
- [x] New `test_ui_conventions.py` fails if a template retypes a retired utility string, if a component class goes missing, or if `static/css/tailwind.css` is stale relative to it — that last one matters because Heroku runs no Node, so an unbuilt CSS change silently never ships
- [x] Browser: checkbox accent, color-scheme and subtitle measure all confirmed via computed styles
- [x] `npm run tailwind:build` committed