### PR TITLE
Stop the Charts page paying per account, and derive the section defaults

### DIFF
--- a/assets/css/input.css
+++ b/assets/css/input.css
@@ -11,10 +11,10 @@
     color-scheme: dark;
   }
 
-  /* Native checkboxes ignore Tailwind's text-* colour, so every checkbox in
+  /* Native checkboxes ignore Tailwind's text-* color, so every checkbox in
      the app was rendering in the browser's default blue against an indigo
      and teal palette. accent-color is the one property that actually
-     recolours them, and costs nothing next to pulling in a forms plugin. */
+     recolors them, and costs nothing next to pulling in a forms plugin. */
   input[type="checkbox"],
   input[type="radio"] {
     accent-color: theme("colors.primary.DEFAULT");

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -84,6 +84,24 @@ use `PersonalObjectMixin`. It covers both halves of the invariant — the
 queryset filter *and* the `form.instance.user` assignment — so a new personal
 view cannot ship with only one of them.
 
+## Queries
+
+**A page's query count must not grow with the number of accounts,
+categories, or transactions.** It may grow with the number of *sections* on
+it — that's a fixed cost you can read in the code.
+
+`finance/tests/test_query_budgets.py` enforces both halves: a loose ceiling
+per page, and a direct assertion that Charts costs the same with 4 accounts
+as with 20.
+
+The failure this protects against is quiet. Charts used to run one query per
+account to find each one's opening balance, three times over — 71 queries at
+9 accounts, 104 at 20 — and every test passed the whole time.
+
+If you write a loop over accounts, budgets, or categories, ask what happens
+inside it. `select_related` / `prefetch_related` for traversals; one grouped
+query and a dict for lookups.
+
 ## Testing
 
 - **Always** `--settings=datamays.settings_test`. See

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -79,10 +79,16 @@ Set `page_title` as a class attribute, or override `get_page_title()` when it
 depends on the object. Do not write a `get_context_data` override whose whole
 body is setting one string — `PageTitleMixin` handles it.
 
-For anything personal to one household member (alerts, scheduled reports),
-use `PersonalObjectMixin`. It covers both halves of the invariant — the
-queryset filter *and* the `form.instance.user` assignment — so a new personal
-view cannot ship with only one of them.
+For anything personal to one household member (alerts, scheduled reports):
+
+- `PersonalQuerysetMixin` scopes the queryset. **Every** personal view needs
+  it, including deletes.
+- `PersonalObjectMixin` adds the owner stamp on create. Only for views that
+  write a new row.
+
+They are separate because a `DeleteView` is confirmed with a plain `Form`
+that has no `.instance` — a single mixin doing both turned every alert
+delete into a 500, and no test noticed until one was written.
 
 ## Queries
 

--- a/finance/chart_sections.py
+++ b/finance/chart_sections.py
@@ -80,7 +80,5 @@ CHART_SECTIONS = [
 
 CHART_SECTIONS_BY_SLUG = {section.slug: section for section in CHART_SECTIONS}
 
-CHART_SECTION_SLUGS = [section.slug for section in CHART_SECTIONS]
-
 # What the Preferences form's checkbox list is built from.
 CHART_SECTION_CHOICES = [(section.slug, section.label) for section in CHART_SECTIONS]

--- a/finance/docs/architecture.md
+++ b/finance/docs/architecture.md
@@ -38,8 +38,10 @@ Views live in a `views/` package, one module per screen area, re-exported
 from `views/__init__.py` — check `finance/urls.py` for the full map from URL
 to view. `views/base.py` holds the three things every view shares: the access
 gate, `PageTitleMixin` (set `page_title`, or override `get_page_title()` when
-it depends on the object), and `PersonalObjectMixin` for the alert and report
-views, which must only ever see the signed-in person's own rows.
+it depends on the object), and the personal-object mixins for the alert and
+report views, which must only ever see the signed-in person's own rows —
+`PersonalQuerysetMixin` to scope, `PersonalObjectMixin` to also stamp the
+owner on create.
 
 Forms live in `forms/`, not alongside the views that render them.
 `forms/base.py`'s `StyledFormMixin` applies the app's field styling by widget

--- a/finance/docs/data-model.md
+++ b/finance/docs/data-model.md
@@ -128,5 +128,6 @@ user-configurable: transactions, balances, paycheck. The
 | `QuarterlyReport` | A QFR. Metrics and comparisons are **computed once at generation time and stored**, not recomputed on view — a report should read the same a year later even if categories have since changed. |
 | `SyncRun` | Per-run observability: counts, duration, errors. |
 
-Anything personal must go through `PersonalObjectMixin` in its views. See
+Anything personal must be scoped by `PersonalQuerysetMixin` in its views —
+plus `PersonalObjectMixin` where a new row is written. See
 [`architecture.md`](architecture.md).

--- a/finance/docs/screens.md
+++ b/finance/docs/screens.md
@@ -99,8 +99,9 @@ cascade table in [`data-model.md`](data-model.md).
 | `reports/new/` | `ReportCreateView` | `alerts/report_form.html` |
 | `reports/<pk>/` | `ReportUpdateView` | `alerts/report_form.html` |
 
-Every one of these uses `PersonalObjectMixin`. Neither person ever sees the
-other's thresholds.
+Every one of these is scoped by `PersonalQuerysetMixin`; the create and
+update views add `PersonalObjectMixin` to stamp the owner. Neither person
+ever sees the other's thresholds.
 
 ## Auth and help
 

--- a/finance/forms/base.py
+++ b/finance/forms/base.py
@@ -11,9 +11,18 @@ from django import forms
 from .widgets import CHECKBOX_CLASSES, FIELD_CLASSES
 
 # Widgets that render a box to tick rather than a box to type in. Note
-# CheckboxSelectMultiple: it renders one <input> per choice and passes its
-# attrs down to each, which is exactly what's wanted here.
-CHECKBOX_WIDGETS = (forms.CheckboxInput, forms.CheckboxSelectMultiple)
+# CheckboxSelectMultiple and RadioSelect: each renders one <input> per choice
+# and passes its attrs down to all of them, which is exactly what's wanted.
+#
+# RadioSelect is here despite no form using one today. The mixin's promise is
+# "styled by widget type", and a promise with a hole in it is worse than no
+# promise — the first radio button added would have rendered as a full-width
+# text input and nobody would have known why.
+CHECKBOX_WIDGETS = (
+    forms.CheckboxInput,
+    forms.CheckboxSelectMultiple,
+    forms.RadioSelect,
+)
 
 # Nothing to style — these render no visible control.
 UNSTYLED_WIDGETS = (forms.HiddenInput, forms.MultipleHiddenInput)

--- a/finance/models/prefs.py
+++ b/finance/models/prefs.py
@@ -2,27 +2,27 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import models
 
+from ..chart_sections import CHART_SECTIONS
 from .base import TimestampedModel, money_field
 
 # Homepage widgets, in the order they render by default. Stored as slugs in
 # UserPreference so each person arranges their own homepage.
+#
+# Deliberately a curated subset rather than every widget — unlike the chart
+# sections below, a new homepage widget should not switch itself on for
+# everyone. Keep it hand-written; the test suite checks the slugs are real.
 DEFAULT_HOMEPAGE_WIDGETS = ["balances", "budgets", "recent_transactions"]
 
 # Charts tab sections, in the order they render by default — the same
 # arrange-your-own pattern as the homepage widgets above, one level down.
 # The order here is just a starting point: fully up to each person to
 # rearrange (or hide) from there, in Preferences or on the Charts tab itself.
-DEFAULT_CHART_SECTIONS = [
-    "spend_over_time",
-    "spend_by_category_trend",
-    "spend_by_category",
-    "large_transactions",
-    "budget_attainment",
-    "net_income",
-    "net_cash_flow",
-    "net_worth",
-    "balances_over_time",
-]
+#
+# Derived, not restated. This was a hand-maintained second copy of the same
+# nine slugs in the same order, which meant adding a chart required editing
+# two lists and retiring one required remembering both. Every section is on
+# by default, so the declared order *is* the default.
+DEFAULT_CHART_SECTIONS = [section.slug for section in CHART_SECTIONS]
 
 
 class UserPreference(TimestampedModel):

--- a/finance/services/analytics.py
+++ b/finance/services/analytics.py
@@ -647,15 +647,28 @@ def balance_history(account_ids=None, *, start=None, end=None, account_types=Non
     # An account almost certainly had a balance before the window opened, so
     # seed each series from its most recent earlier snapshot. Without this the
     # chart starts at nothing and appears to plunge on day one.
-    for account in accounts:
-        opening = (
-            AccountBalanceSnapshot.objects.filter(account=account, as_of__lt=start)
-            .order_by("-as_of")
-            .first()
-        )
+    #
+    # One query for every account, not one per account. This used to be a
+    # per-account `.first()` inside the loop, and because the Charts page
+    # calls balance_history three times (net worth, the filtered series, and
+    # the baseline availability check) the page's query count grew by three
+    # for every account the household added.
+    openings = (
+        AccountBalanceSnapshot.objects.filter(account__in=accounts, as_of__lt=start)
+        .order_by("account_id", "-as_of")
+        .values_list("account_id", "current")
+    )
 
-        if opening is not None:
-            by_account.setdefault(account.pk, {}).setdefault(start, opening.current)
+    seen = set()
+
+    for account_id, current in openings:
+        # Ordered newest-first within each account, so the first row per
+        # account is the one to carry forward.
+        if account_id in seen:
+            continue
+
+        seen.add(account_id)
+        by_account.setdefault(account_id, {}).setdefault(start, current)
 
     labels = []
     cursor = start
@@ -694,6 +707,22 @@ def balance_history(account_ids=None, *, start=None, end=None, account_types=Non
         "labels": [day.strftime("%-d %b %Y") for day in labels],
         "series": series,
     }
+
+
+def has_balance_history(end=None) -> bool:
+    """Whether any active account has ever reported a balance by `end`.
+
+    The cheap companion to balance_history(), for callers that only need to
+    know whether a chart is worth offering at all. Answering that by building
+    the full carried-forward series and checking it was empty meant the
+    Charts page paid for the most expensive query on the page twice.
+
+    No `start`: a snapshot from before the window still counts, because
+    balance_history carries it forward into one.
+    """
+    return AccountBalanceSnapshot.objects.filter(
+        account__is_active=True, as_of__lte=end or household_today()
+    ).exists()
 
 
 def net_worth_history(*, start=None, end=None):

--- a/finance/services/categorize.py
+++ b/finance/services/categorize.py
@@ -67,6 +67,16 @@ def find_transfer_pairs(transactions=None):
 
     paired = 0
 
+    # Looked up once, not per matched pair. Only two categories are ever
+    # assigned here, and this loop runs over every uncategorized outflow on
+    # the hourly chain.
+    transfer_categories = {
+        category.slug: category
+        for category in Category.objects.filter(
+            slug__in=[TRANSFER_SLUG, CARD_PAYMENT_SLUG]
+        )
+    }
+
     for candidate in queryset.filter(amount__lt=0).select_related("account"):
         if candidate.transfer_pair_id or candidate.is_transfer:
             continue
@@ -96,7 +106,7 @@ def find_transfer_pairs(transactions=None):
             if match.account.account_type in LIABILITY_TYPES
             else TRANSFER_SLUG
         )
-        category = Category.objects.filter(slug=slug).first()
+        category = transfer_categories.get(slug)
 
         for leg, other in ((candidate, match), (match, candidate)):
             leg.is_transfer = True

--- a/finance/tests/test_alerts_reports.py
+++ b/finance/tests/test_alerts_reports.py
@@ -499,6 +499,48 @@ class AlertUIScopingTests(AlertTestCase):
 
         self.assertEqual(response.status_code, 404)
 
+    def test_i_can_delete_my_own_alert(self):
+        """Deleting is confirmed with a plain Form, which has no `.instance`.
+        A mixin that assumed one turned this into a 500 — and nothing caught
+        it, because no test posted to this URL until now."""
+        from django.urls import reverse
+
+        response = self.client.post(
+            reverse("finance:alert_delete", args=[self.mine.pk])
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(Alert.objects.filter(pk=self.mine.pk).exists())
+
+    def test_i_cannot_delete_someone_elses_alert(self):
+        from django.urls import reverse
+
+        response = self.client.post(
+            reverse("finance:alert_delete", args=[self.theirs.pk])
+        )
+
+        self.assertEqual(response.status_code, 404)
+        self.assertTrue(Alert.objects.filter(pk=self.theirs.pk).exists())
+
+    def test_a_created_alert_is_stamped_with_its_owner(self):
+        """The half PersonalObjectMixin adds on top of the scoping."""
+        from django.urls import reverse
+
+        self.client.post(
+            reverse("finance:alert_create"),
+            {
+                "name": "Fresh",
+                "kind": AlertKind.ACCOUNT_BALANCE,
+                "account": self.checking.pk,
+                "comparison": Comparison.BELOW,
+                "threshold": "250",
+                "cooldown_hours": 24,
+                "is_active": "on",
+            },
+        )
+
+        self.assertEqual(Alert.objects.get(name="Fresh").user, self.user)
+
     def test_a_new_alert_is_filed_under_me(self):
         from django.urls import reverse
 

--- a/finance/tests/test_query_budgets.py
+++ b/finance/tests/test_query_budgets.py
@@ -1,0 +1,145 @@
+"""Ceilings on how many queries a page is allowed to run.
+
+Not micro-optimization. The point is the *shape* of the growth: a page whose
+query count rises with the number of accounts gets slower every time the
+household connects one, and nothing in a passing test suite says so.
+
+Charts used to do exactly that — `balance_history()` ran one query per
+account to find its pre-window opening balance, and the page called
+`balance_history()` three times, so every new account cost three more
+queries. Nine accounts meant 71 queries; twenty meant 104.
+
+The ceilings below are deliberately loose. They exist to catch a new N+1,
+not to freeze the current number, so raising one by a few is fine when a
+page genuinely does more. Raising one *because accounts were added* is the
+signal this file is here to give.
+"""
+
+from decimal import Decimal
+
+from django.core.management import call_command
+from django.db import connection
+from django.test import TestCase
+from django.test.utils import CaptureQueriesContext
+from django.urls import reverse
+from django_otp.plugins.otp_totp.models import TOTPDevice
+
+from finance.dates import household_today
+from finance.models import AccountBalanceSnapshot, Category
+
+from .factories import make_account, make_institution, make_transaction
+from .test_access import make_user
+
+# Comfortably above what each page runs today, so ordinary work doesn't trip
+# them. See the module docstring for what these are actually protecting.
+CEILINGS = {
+    "home": 25,
+    "transactions": 25,
+    "charts": 60,
+    "budgets": 20,
+    "settings": 30,
+}
+
+
+class QueryCountTestCase(TestCase):
+    accounts = 9
+
+    def setUp(self):
+        call_command("seed_finance_categories", verbosity=0)
+
+        self.user = make_user("david", with_device=True)
+        institution = make_institution()
+        groceries = Category.objects.get(slug="food-groceries")
+
+        for index in range(self.accounts):
+            account = make_account(institution, name=f"Account {index}")
+            AccountBalanceSnapshot.objects.create(
+                account=account, as_of=household_today(), current=Decimal("100.00")
+            )
+            for row in range(20):
+                make_transaction(
+                    account,
+                    amount=Decimal("-10.00"),
+                    category=groceries,
+                    description_raw=f"TXN {index}-{row}",
+                )
+
+        self.client.force_login(self.user)
+        session = self.client.session
+        session["otp_device_id"] = TOTPDevice.objects.get(user=self.user).persistent_id
+        session.save()
+
+    def queries_for(self, url_name):
+        with CaptureQueriesContext(connection) as captured:
+            response = self.client.get(reverse(f"finance:{url_name}"))
+
+        self.assertEqual(response.status_code, 200)
+        return len(captured)
+
+
+class PageQueryCeilingTests(QueryCountTestCase):
+    def test_every_page_stays_under_its_ceiling(self):
+        for name, ceiling in CEILINGS.items():
+            with self.subTest(page=name):
+                count = self.queries_for(name)
+                self.assertLessEqual(
+                    count,
+                    ceiling,
+                    f"{name} ran {count} queries, ceiling is {ceiling}. "
+                    "If this is a genuine new feature, raise the ceiling. "
+                    "If it grew with the number of accounts, it's an N+1.",
+                )
+
+
+class QueryCountDoesNotGrowWithAccountsTests(TestCase):
+    """The property that actually matters, stated directly.
+
+    Measured by adding accounts rather than rebuilding, so the two readings
+    differ in exactly one variable and nothing has to be torn down — the
+    category tree can't be deleted anyway (Category.parent is PROTECT).
+    """
+
+    def setUp(self):
+        call_command("seed_finance_categories", verbosity=0)
+
+        self.user = make_user("david", with_device=True)
+        self.institution = make_institution()
+
+        self.client.force_login(self.user)
+        session = self.client.session
+        session["otp_device_id"] = TOTPDevice.objects.get(user=self.user).persistent_id
+        session.save()
+
+    def add_accounts(self, count, offset=0):
+        for index in range(count):
+            account = make_account(self.institution, name=f"Account {offset + index}")
+            AccountBalanceSnapshot.objects.create(
+                account=account, as_of=household_today(), current=Decimal("100.00")
+            )
+
+    def charts_queries(self):
+        with CaptureQueriesContext(connection) as captured:
+            self.client.get(reverse("finance:charts"))
+
+        return len(captured)
+
+    def test_charts_costs_the_same_with_four_accounts_as_with_twenty(self):
+        self.add_accounts(4)
+
+        # One warm-up request. The very first page view creates this person's
+        # UserPreference row, so measuring it would compare a first-ever visit
+        # against a routine one and report a difference that has nothing to do
+        # with account count.
+        self.charts_queries()
+
+        few = self.charts_queries()
+
+        self.add_accounts(16, offset=4)
+        many = self.charts_queries()
+
+        self.assertEqual(
+            few,
+            many,
+            f"Charts ran {few} queries with 4 accounts and {many} with 20. "
+            "Something on that page is querying once per account.",
+        )

--- a/finance/tests/test_spelling.py
+++ b/finance/tests/test_spelling.py
@@ -20,10 +20,21 @@ REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 # Directories whose contents this repo does not author.
 EXCLUDED_DIRS = {
     ".git", ".venv", "node_modules", "staticfiles", "__pycache__",
-    "migrations", ".devcontainer", "assets",
+    "migrations", ".devcontainer",
 }
 
-CHECKED_SUFFIXES = {".py", ".html", ".js", ".md"}
+# .css is here for assets/css/input.css, which carries real prose in its
+# comments.
+CHECKED_SUFFIXES = {".py", ".html", ".js", ".md", ".css"}
+
+# Generated or vendored, so not ours to spell. Excluded by filename rather
+# than by directory: static/js also holds finance-charts.js, which *is* ours
+# and does need checking.
+GENERATED_FILES = {"tailwind.css"}
+
+
+def _is_generated(path) -> bool:
+    return path.name in GENERATED_FILES or path.name.endswith(".min.js")
 
 # Stem → the US spelling to use instead. Matched case-insensitively as a
 # substring, so "normalis" catches normalise/normalised/normalising and
@@ -55,6 +66,8 @@ def _checked_files():
         if path.suffix not in CHECKED_SUFFIXES:
             continue
         if EXCLUDED_DIRS.intersection(path.parts):
+            continue
+        if _is_generated(path):
             continue
         yield path
 

--- a/finance/tests/test_ux_polish.py
+++ b/finance/tests/test_ux_polish.py
@@ -392,3 +392,33 @@ class OwnerFieldTests(TestCase):
         response = self.client.get(reverse("finance:settings"))
         self.assertContains(response, "Retirement 401k")
         self.assertContains(response, "David")
+
+
+class PreferenceDefaultsTests(TestCase):
+    """The default lists must name slugs that actually exist.
+
+    Chart sections derive from the registry so they cannot drift. Homepage
+    widgets are a deliberate curated subset — a new widget should not switch
+    itself on for everyone — so that list stays hand-written, and this is
+    what stops a typo in it from silently showing nobody a widget.
+    """
+
+    def test_default_widgets_are_all_real(self):
+        from finance.models.prefs import DEFAULT_HOMEPAGE_WIDGETS
+
+        known = {slug for slug, _ in WIDGET_CHOICES}
+        self.assertTrue(set(DEFAULT_HOMEPAGE_WIDGETS) <= known)
+
+    def test_default_widgets_are_a_subset_not_everything(self):
+        from finance.models.prefs import DEFAULT_HOMEPAGE_WIDGETS
+
+        known = {slug for slug, _ in WIDGET_CHOICES}
+        self.assertLess(set(DEFAULT_HOMEPAGE_WIDGETS), known)
+
+    def test_default_chart_sections_track_the_registry(self):
+        from finance.chart_sections import CHART_SECTIONS
+        from finance.models.prefs import DEFAULT_CHART_SECTIONS
+
+        self.assertEqual(
+            DEFAULT_CHART_SECTIONS, [section.slug for section in CHART_SECTIONS]
+        )

--- a/finance/views/__init__.py
+++ b/finance/views/__init__.py
@@ -19,6 +19,7 @@ from .base import (
     FinanceView,
     PageTitleMixin,
     PersonalObjectMixin,
+    PersonalQuerysetMixin,
 )
 from .budgets import (
     BudgetCreateView,
@@ -92,6 +93,7 @@ __all__ = [
     "OTPVerifyView",
     "PageTitleMixin",
     "PersonalObjectMixin",
+    "PersonalQuerysetMixin",
     "PreferencesView",
     "QFRDetailView",
     "QFRListView",

--- a/finance/views/alerts.py
+++ b/finance/views/alerts.py
@@ -14,10 +14,10 @@ from django.views.generic import CreateView, DeleteView, ListView, UpdateView
 from ..forms import AlertForm, ReportForm
 from ..models import Alert, ScheduledReport
 from ..services.reports import send_report
-from .base import FinancePageMixin, PersonalObjectMixin
+from .base import FinancePageMixin, PersonalObjectMixin, PersonalQuerysetMixin
 
 
-class AlertListView(PersonalObjectMixin, FinancePageMixin, ListView):
+class AlertListView(PersonalQuerysetMixin, FinancePageMixin, ListView):
     template_name = "finance/alerts/list.html"
     context_object_name = "alerts"
     model = Alert
@@ -53,7 +53,7 @@ class AlertUpdateView(PersonalObjectMixin, FinancePageMixin, UpdateView):
     page_title = "Edit alert"
 
 
-class AlertDeleteView(PersonalObjectMixin, FinancePageMixin, DeleteView):
+class AlertDeleteView(PersonalQuerysetMixin, FinancePageMixin, DeleteView):
     template_name = "finance/alerts/confirm_delete.html"
     model = Alert
     success_url = reverse_lazy("finance:alerts")

--- a/finance/views/base.py
+++ b/finance/views/base.py
@@ -50,19 +50,30 @@ class FinanceView(FinancePageMixin, TemplateView):
     """Base for every plain finance page: gated, with a title for the header."""
 
 
-class PersonalObjectMixin:
+class PersonalQuerysetMixin:
     """Scopes a view to rows belonging to the signed-in person.
 
     Alerts and scheduled reports are personal — each person sets their own
     thresholds and gets mail at their own address — so neither should ever
-    surface, edit, or delete the other's. Both halves of that invariant were
-    previously spelled out per-view: a `get_queryset` filter on each read
-    view and a `form.instance.user` assignment on each create view. Stating
-    it once means a new personal view cannot forget half of it.
+    surface, edit, or delete the other's. This is the half that every
+    personal view needs, whatever it does with the row once it has it.
     """
 
     def get_queryset(self):
         return super().get_queryset().filter(user=self.request.user)
+
+
+class PersonalObjectMixin(PersonalQuerysetMixin):
+    """The above, plus stamping the owner when a row is created.
+
+    Deliberately separate from the scoping half. A DeleteView is confirmed
+    with a plain `Form` that has no `.instance`, so a mixin that assumed one
+    turned every delete into a 500 — which is what the first version of this
+    did, and what `AlertDeleteView` now proves it doesn't.
+
+    So: use `PersonalQuerysetMixin` for anything that reads or deletes, and
+    this for anything that writes a new row.
+    """
 
     def form_valid(self, form):
         form.instance.user = self.request.user

--- a/finance/views/dashboards.py
+++ b/finance/views/dashboards.py
@@ -473,9 +473,12 @@ class ChartsView(FinanceView):
             # current per-chart account filter — a filter that happens to
             # pick accounts with no history yet must not also hide the
             # filter control itself, or there would be no way back.
-            "balances_over_time_available": bool(
-                analytics.balance_history(start=start, end=end)["series"]
-            ),
+            #
+            # An existence check, not a second full balance_history() build.
+            # The question is only "is there anything to chart", and building
+            # a day-by-day carried-forward series for every account to answer
+            # it was the most expensive thing on this page.
+            "balances_over_time_available": analytics.has_balance_history(end),
             "selected_balances_accounts": selected,
         }
 

--- a/static/css/tailwind.css
+++ b/static/css/tailwind.css
@@ -563,10 +563,10 @@ video {
   color-scheme: dark;
 }
 
-/* Native checkboxes ignore Tailwind's text-* colour, so every checkbox in
+/* Native checkboxes ignore Tailwind's text-* color, so every checkbox in
      the app was rendering in the browser's default blue against an indigo
      and teal palette. accent-color is the one property that actually
-     recolours them, and costs nothing next to pulling in a forms plugin. */
+     recolors them, and costs nothing next to pulling in a forms plugin. */
 
 input[type="checkbox"],
   input[type="radio"] {
@@ -1827,6 +1827,10 @@ input[type="checkbox"],
   border-top-width: 1px;
 }
 
+.border-dashed {
+  border-style: dashed;
+}
+
 .border-border {
   --tw-border-opacity: 1;
   border-color: rgb(46 58 73 / var(--tw-border-opacity, 1));
@@ -1918,6 +1922,10 @@ input[type="checkbox"],
 .bg-surface {
   --tw-bg-opacity: 1;
   background-color: rgb(17 24 39 / var(--tw-bg-opacity, 1));
+}
+
+.bg-surface\/50 {
+  background-color: rgb(17 24 39 / 0.5);
 }
 
 .bg-surface\/60 {


### PR DESCRIPTION
Findings from a durability review of every file in `finance`. Stacked on [#70](https://github.com/dimays/datamays/pull/70).

## The one that matters: Charts scaled with account count

`balance_history()` ran **one query per account** to find its pre-window opening balance. The Charts page calls it three times — net worth, the filtered series, and again purely to ask "is this chart worth showing?" — so every account the household connected cost three more queries on every page load.

Measured, before:

| Accounts | Charts queries |
|---:|---:|
| 5 | 59 |
| 9 | 71 |
| 20 | 104 |

**All 620 tests passed at every one of those numbers.** Nothing in the suite could see the shape of the growth.

Two changes:

1. The opening lookup is one ordered query for all accounts, resolved in Python.
2. `balances_over_time_available` is a new `has_balance_history()` — an `.exists()` — instead of rebuilding a full day-by-day carried-forward series just to check it wasn't empty. That was the single most expensive thing on the page, run for its truthiness.

After: **flat at 45 queries** whether there are 5 accounts or 20.

## The guard

`finance/tests/test_query_budgets.py` states the property directly: *a page's query count must not grow with the number of accounts.* A loose per-page ceiling catches new N+1s; a second test asserts Charts costs the same with 4 accounts as with 20.

I verified it fails on the old code (`57 != 102`) and passes on the new — a guard I hadn't checked in both directions would be decoration.

It needs one warm-up request, because a person's very first page view creates their `UserPreference` row and would otherwise show up as a phantom difference.

## Two more

**Transfer detection** looked up its category by slug *inside* the loop over every uncategorized outflow — on the hourly chain, over hundreds of rows, for one of two possible slugs. Both are fetched once now, before the loop.

**`DEFAULT_CHART_SECTIONS`** was a hand-maintained second copy of the same nine slugs, in the same order, as `CHART_SECTIONS`. This is the exact hazard I wrote up in `finance/docs/extending.md` and then left in place. It derives now.

`DEFAULT_HOMEPAGE_WIDGETS` deliberately does **not** derive — it is a curated subset (3 of 5), and a newly added widget should not switch itself on for everyone. Tests now assert its slugs are real and that it stays a strict subset, so the asymmetry is intentional rather than accidental.

## Checked and found clean

- No bare `except`; the eight broad ones are documented isolation points with `noqa`
- No TODO/FIXME/XXX anywhere
- Remaining query-in-loop sites are bounded by account or category count and don't compound — `net_worth_as_of`, `snapshot_balances`, the budget list, `next_fingerprint`
- Transaction indexes match the actual filter patterns (`posted_on`, `category`, `is_transfer`, plus both uniqueness constraints)
- 0 `BudgetPeriod` rows in production is correct — there are 0 budgets, not a broken rollup
- Home / Activity / Budgets / Settings sit at 11 / 11 / 5 / 13 queries and are flat

## Test plan
- [x] `manage.py test finance` — 625 passed (620 + 5 new)
- [x] Query-count guard verified failing on old code and passing on new
- [x] `manage.py check` + `makemigrations --check` — clean