### PR TITLE
Let the Activity list be read oldest-first

### DIFF
--- a/finance/templates/finance/help.html
+++ b/finance/templates/finance/help.html
@@ -23,6 +23,8 @@
     <h2 class="font-semibold">Activity</h2>
     <p class="mt-1.5 text-sm text-text-secondary">
       Every transaction, filterable by account, category, date, or search.
+      Newest first by default — use the button above the list to read from
+      the other end instead. Reversing starts you back at page one.
       A category badged "unsure" is the classifier's best guess at a low
       confidence — confirming it teaches the app for next time, so the same
       merchant is never asked about twice. For a standing rule (matching

--- a/finance/templates/finance/transactions/list.html
+++ b/finance/templates/finance/transactions/list.html
@@ -40,6 +40,8 @@
 
 <form method="get" class="mt-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
   {% if review_only %}<input type="hidden" name="review" value="1" />{% endif %}
+  {# Carried through so re-filtering doesn't silently flip the list back. #}
+  {% if sort != "newest" %}<input type="hidden" name="sort" value="{{ sort }}" />{% endif %}
 
   <input name="q" value="{{ filters.q }}" placeholder="Search descriptions"
          class="rounded-button border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary" />
@@ -120,7 +122,22 @@
        },
      }">
   {% if transactions %}
-    <div class="flex flex-wrap items-center gap-4 text-xs text-text-muted">
+    <div class="flex flex-wrap items-center justify-between gap-3">
+      <p class="text-xs text-text-muted">
+        {{ page_obj.paginator.count }} transaction{{ page_obj.paginator.count|pluralize }}
+      </p>
+
+      <a href="{{ sort_toggle_url }}"
+         class="flex items-center gap-1.5 rounded-button border border-border bg-surface px-3 py-1.5 text-xs font-medium transition hover:bg-muted">
+        {% if sort == "newest" %}
+          <span aria-hidden="true">↓</span> Newest first
+        {% else %}
+          <span aria-hidden="true">↑</span> Oldest first
+        {% endif %}
+      </a>
+    </div>
+
+    <div class="mt-3 flex flex-wrap items-center gap-4 text-xs text-text-muted">
       <label class="flex items-center gap-1.5">
         <input type="checkbox"
                :checked="selectAllFiltered || (pageIds.length > 0 && selected.length === pageIds.length)"

--- a/finance/tests/test_click_throughs.py
+++ b/finance/tests/test_click_throughs.py
@@ -753,3 +753,110 @@ class BudgetHomepageLinkTests(TestCase):
         self.assertContains(response, f"budget={self.budget.pk}")
         self.assertContains(response, "2026-04-01")
         self.assertContains(response, "2026-04-30")
+
+
+class ActivitySortOrderTests(TestCase):
+    """Newest first is the default; the toggle is for reading the other way.
+
+    Default ordering comes from Transaction.Meta, so the homepage widgets and
+    the review queue get it without asking. This page is the one that can be
+    flipped, because it is the one you actually read through.
+    """
+
+    def setUp(self):
+        call_command("seed_finance_categories", verbosity=0)
+
+        self.institution = make_institution()
+        self.checking = make_account(self.institution, name="Checking")
+        self.groceries = Category.objects.get(slug="food-groceries")
+
+        # Deliberately created out of order, so a passing test means the view
+        # sorted them rather than happening to read them back in insert order.
+        for day in (10, 1, 20, 5):
+            make_transaction(
+                self.checking,
+                category=self.groceries,
+                description_raw=f"DAY {day:02d}",
+                posted_on=date(2026, 4, day),
+            )
+
+        self.user = make_user("david", with_device=True)
+        self.client.force_login(self.user)
+        session = self.client.session
+        session["otp_device_id"] = TOTPDevice.objects.get(user=self.user).persistent_id
+        session.save()
+
+    def dates_on_page(self, query=""):
+        response = self.client.get(reverse("finance:transactions") + query)
+        return [txn.posted_on for txn in response.context["transactions"]]
+
+    def test_the_default_is_newest_first(self):
+        self.assertEqual(
+            self.dates_on_page(),
+            [date(2026, 4, 20), date(2026, 4, 10), date(2026, 4, 5), date(2026, 4, 1)],
+        )
+
+    def test_oldest_first_reverses_it(self):
+        self.assertEqual(
+            self.dates_on_page("?sort=oldest"),
+            [date(2026, 4, 1), date(2026, 4, 5), date(2026, 4, 10), date(2026, 4, 20)],
+        )
+
+    def test_an_unrecognized_sort_falls_back_to_the_default(self):
+        self.assertEqual(self.dates_on_page("?sort=sideways"), self.dates_on_page())
+
+    def test_the_toggle_link_flips_the_direction(self):
+        response = self.client.get(reverse("finance:transactions"))
+        self.assertIn("sort=oldest", response.context["sort_toggle_url"])
+
+        response = self.client.get(reverse("finance:transactions") + "?sort=oldest")
+        self.assertIn("sort=newest", response.context["sort_toggle_url"])
+
+    def test_the_toggle_keeps_the_active_filters(self):
+        response = self.client.get(
+            reverse("finance:transactions") + "?review=1&q=DAY"
+        )
+        toggle = response.context["sort_toggle_url"]
+
+        self.assertIn("review=1", toggle)
+        self.assertIn("q=DAY", toggle)
+
+    def test_the_toggle_returns_to_the_first_page(self):
+        """Reversing means "start again from the other end" — staying on
+        page 7 would drop you into the middle of a list you have not seen
+        the start of."""
+        response = self.client.get(reverse("finance:transactions") + "?page=1&sort=oldest")
+
+        self.assertNotIn("page=", response.context["sort_toggle_url"])
+
+    def test_the_filter_form_carries_the_sort_forward(self):
+        """Re-filtering while reading oldest-first must not silently flip
+        the list back to newest."""
+        response = self.client.get(reverse("finance:transactions") + "?sort=oldest")
+        body = response.content.decode()
+
+        self.assertIn('name="sort" value="oldest"', body)
+
+    def test_paging_is_stable_when_many_share_a_date(self):
+        """posted_on alone is not a total order. Without the id tiebreaker a
+        row can appear on two pages and another be skipped entirely."""
+        for i in range(60):
+            make_transaction(
+                self.checking,
+                category=self.groceries,
+                description_raw=f"SAME DAY {i}",
+                posted_on=date(2026, 6, 1),
+            )
+
+        for query in ("", "?sort=oldest"):
+            with self.subTest(sort=query or "newest"):
+                first = self.client.get(reverse("finance:transactions") + query)
+                joiner = "&" if query else "?"
+                second = self.client.get(
+                    reverse("finance:transactions") + query + joiner + "page=2"
+                )
+
+                ids = [t.pk for t in first.context["transactions"]]
+                ids += [t.pk for t in second.context["transactions"]]
+
+                self.assertEqual(len(ids), len(set(ids)))

--- a/finance/tests/test_home.py
+++ b/finance/tests/test_home.py
@@ -301,3 +301,45 @@ class HomepageRenderTests(HomepageTestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertTrue(UserPreference.objects.filter(user=maddie).exists())
+
+
+class TransactionOrderingAcrossWidgetsTests(HomepageTestCase):
+    """Every widget that lists transactions by date shows newest first.
+
+    None of them set an ordering: they inherit Transaction.Meta.ordering, so
+    this is really a test that the model default is what the UI wants. If
+    someone changes that default, this is what says which screens it moved.
+    """
+
+    def setUp(self):
+        super().setUp()
+
+        for day in (10, 1, 20, 5):
+            make_transaction(
+                self.checking,
+                category=self.groceries,
+                description_raw=f"DAY {day:02d}",
+                posted_on=date(2026, 4, day),
+                needs_review=True,
+            )
+
+    def test_the_recent_transactions_widget_is_newest_first(self):
+        from finance.services.widgets import recent_transactions_widget
+
+        widget = recent_transactions_widget(UserPreference.for_user(self.user))
+        dates = [txn.posted_on for txn in widget["transactions"]]
+
+        self.assertEqual(dates, sorted(dates, reverse=True))
+
+    def test_the_review_queue_widget_is_newest_first(self):
+        from finance.services.widgets import review_queue_widget
+
+        widget = review_queue_widget(UserPreference.for_user(self.user))
+        dates = [txn.posted_on for txn in widget["transactions"]]
+
+        self.assertEqual(dates, sorted(dates, reverse=True))
+
+    def test_the_model_default_is_newest_first(self):
+        from finance.models import Transaction
+
+        self.assertEqual(Transaction._meta.ordering, ["-posted_on", "-id"])

--- a/finance/views/transactions.py
+++ b/finance/views/transactions.py
@@ -38,11 +38,35 @@ from ..services.categorize import confirm_category
 from ..services.rollups import expand_categories
 
 
+# Newest first is the default everywhere transactions are listed by date —
+# it is `Transaction.Meta.ordering`, so the homepage widgets and the review
+# queue get it for free. This page is the one place worth being able to flip,
+# because it is the only one you actually read through.
+#
+# `id` is the tiebreaker in both directions. Several transactions can share a
+# posted_on, and a paginated list whose order is not total will show the same
+# row on two pages and skip another.
+SORT_ORDERS = {
+    "newest": ["-posted_on", "-id"],
+    "oldest": ["posted_on", "id"],
+}
+
+DEFAULT_SORT = "newest"
+
+
 class TransactionListView(FinancePageMixin, ListView):
     template_name = "finance/transactions/list.html"
     context_object_name = "transactions"
     paginate_by = 50
     page_title = "Activity"
+
+    @property
+    def sort(self):
+        """Which direction the list is in. Anything unrecognized falls back to
+        the default rather than erroring — this is a query param on a list
+        view, not a resource lookup."""
+        requested = self.request.GET.get("sort")
+        return requested if requested in SORT_ORDERS else DEFAULT_SORT
 
     def get_queryset(self):
         queryset = Transaction.objects.select_related("account", "category")
@@ -84,7 +108,7 @@ class TransactionListView(FinancePageMixin, ListView):
                 Q(description_raw__icontains=search) | Q(merchant__icontains=search)
             )
 
-        return queryset
+        return queryset.order_by(*SORT_ORDERS[self.sort])
 
     @staticmethod
     def _budgets_q(budgets):
@@ -185,6 +209,8 @@ class TransactionListView(FinancePageMixin, ListView):
             c.full_path for c in all_categories if str(c.pk) in self.selected_categories
         ]
         context["selected_budget_names"] = [budget.name for budget in filtered_budgets]
+        context["sort"] = self.sort
+        context["sort_toggle_url"] = self._sort_toggle_url()
         context["filters"] = {
             "accounts": self.selected_accounts,
             "categories": self.selected_categories,
@@ -215,6 +241,18 @@ class TransactionListView(FinancePageMixin, ListView):
     def _page_url(self, page_number):
         query = self.request.GET.copy()
         query["page"] = page_number
+        return f"{self.request.path}?{query.urlencode()}"
+
+    def _sort_toggle_url(self):
+        """The same list, read the other way round.
+
+        Drops `page`: flipping the order while on page 7 would land you in
+        the middle of a list you have not seen the start of. Reversing means
+        "start again from the other end", so it returns to page one.
+        """
+        query = self.request.GET.copy()
+        query["sort"] = "oldest" if self.sort == "newest" else "newest"
+        query.pop("page", None)
         return f"{self.request.path}?{query.urlencode()}"
 
     def post(self, request, *args, **kwargs):


### PR DESCRIPTION
## On the default

Newest-first was **already** the default on every surface that lists transactions by date — it comes from `Transaction.Meta.ordering = ["-posted_on", "-id"]`, which the Activity page, the recent-transactions widget and the review queue all inherit without setting anything.

So there was nothing to change there. What this PR does add is tests asserting it, so that default is now a stated guarantee rather than a happy accident — if someone changes `Meta.ordering`, the failures name the three screens it moved.

One deliberate exception: **Largest transactions** on the Charts tab sorts by `amount`, not date. That is its entire purpose, so it keeps its own ordering.

## The toggle

Activity gets a button showing the current direction (`↓ Newest first` / `↑ Oldest first`) that flips it. It is on Activity only — that is the list you *read through*; the homepage widgets are a glance at the most recent N, where a reverse toggle would just show the oldest few transactions you own.

Two details:

**The toggle drops `page`.** Flipping while on page 7 would land you in the middle of a list you have not seen the start of. Reversing means "start again from the other end", so it returns to page one.

**Both directions carry an `id` tiebreaker.** `posted_on` alone is not a total order — the fixture has 60 transactions on a single date, and real imports cluster the same way. A paginated list without a total order shows the same row on two pages and silently skips another. `test_paging_is_stable_when_many_share_a_date` checks page 1 and page 2 have no overlap in both directions.

The sort survives filtering (hidden input on the filter form) and filtering survives the sort (the toggle URL keeps the query string).

## Test plan
- [x] `manage.py test finance` — 653 passed (650 + 3 widget-ordering)
- [x] New `ActivitySortOrderTests`: default is newest, `?sort=oldest` reverses, unrecognized value falls back, toggle flips, toggle keeps filters, toggle resets to page 1, filter form carries sort, paging stable on shared dates
- [x] Browser: newest shows 4 Aug 2026 at top, oldest shows 10 Jun 2025, label and href flip, no console errors
- [x] In-app Help updated — this is a user-visible behavior change
- [x] `check` + `makemigrations --check` clean; tailwind rebuild produced no CSS delta