### PR TITLE
Let a sync claim a CSV row instead of duplicating it

### DIFF
--- a/finance/docs/pipeline.md
+++ b/finance/docs/pipeline.md
@@ -19,6 +19,45 @@ where the provider supplies one, and by a content fingerprint where it does
 not. Re-running a sync immediately must not change the transaction count —
 there is a test for exactly that.
 
+### The deduplication rule
+
+**Within one source, trust it. Across sources, deduplicate.**
+
+A CSV file listing three identical $4.75 coffees is asserting three coffees
+happened. A sync payload carrying three with distinct provider ids is
+asserting the same. Neither gets second-guessed — collapsing them would
+silently delete real spending.
+
+Two exports covering the same week, or a CSV import the provider later
+reports, are the same money described twice. Those collapse.
+
+| Situation | Result |
+|---|---|
+| One file, three identical rows | 3 transactions |
+| The same file imported twice | 3 transactions |
+| Two files, one identical row each | 1 transaction |
+| A file with one row, then a cumulative export with three | 3 transactions |
+| One sync payload, three identical (distinct provider ids) | 3 transactions |
+| A CSV row the provider later reports | 1 transaction |
+
+Two mechanisms enforce it, and they must agree:
+
+- The importer counts *occurrences* — the row's index within the file against
+  how many matching rows already exist. A plain "does a match exist" check
+  would drop the genuinely-new coffees in the cumulative-export case.
+- The sync only claims rows with **no** `provider_txn_id`, which is exactly
+  the CSV-imported case. A row another payload already claimed is invisible
+  to it.
+
+Both use `models.transactions.same_transaction()` for "is this the same
+movement of money". They previously did not, and the gap created a duplicate
+of every CSV-imported transaction the provider later reported — the sync had
+no ledger check at all, and `next_fingerprint()` stepped past the fingerprint
+collision that would otherwise have caught it.
+
+Stated in tests as `test_csv_import.SourceOfTruthTests` and
+`test_sync.SyncTrustsItsOwnPayloadTests`.
+
 **Sign normalization** happens here, at the boundary
 (`normalize_balance()`). Nothing downstream guesses. See
 [ADR 0003](../../docs/architecture/decisions/0003-household-sign-convention.md).

--- a/finance/models/__init__.py
+++ b/finance/models/__init__.py
@@ -66,6 +66,7 @@ from .transactions import (
     Transaction,
     TransactionSource,
     build_fingerprint,
+    same_transaction,
 )
 
 __all__ = [
@@ -121,5 +122,6 @@ __all__ = [
     "UNIT_HOURS",
     "UserPreference",
     "build_fingerprint",
+    "same_transaction",
     "money_field",
 ]

--- a/finance/models/transactions.py
+++ b/finance/models/transactions.py
@@ -41,6 +41,28 @@ def build_fingerprint(*, account_id, posted_on, amount, description, sequence=0)
     return hashlib.sha256(raw.encode()).hexdigest()
 
 
+def same_transaction(account_id, posted_on, amount, description):
+    """Rows that represent the same real-world movement of money.
+
+    The one definition of "we already have this", shared by both paths that
+    write transactions. It has to be shared: the CSV importer had this check
+    and the provider sync did not, so a transaction imported by CSV and later
+    reported by the provider was created twice. The sync matched only on
+    `provider_txn_id`, which a CSV row does not have, and then `next_fingerprint`
+    politely stepped around the fingerprint collision that would otherwise
+    have caught it.
+
+    Deliberately not matching on source or provider id — the whole point is to
+    recognize the same transaction arriving by a different route.
+    """
+    return Transaction.objects.filter(
+        account_id=account_id,
+        posted_on=posted_on,
+        amount=amount,
+        description_raw__iexact=(description or "").strip(),
+    )
+
+
 class Transaction(TimestampedModel):
     """One posted movement of money.
 

--- a/finance/services/importer.py
+++ b/finance/services/importer.py
@@ -22,6 +22,7 @@ from ..models import (
     RowStatus,
     Transaction,
     TransactionSource,
+    same_transaction,
 )
 from .detection import parse_amount, parse_date, sniff
 from .sync import (
@@ -238,11 +239,14 @@ def _is_duplicate(batch, parsed, occurrences):
         index_in_file = occurrences.get(key, 0)
         occurrences[key] = index_in_file + 1
 
-        already_in_ledger = Transaction.objects.filter(
-            account_id=batch.account_id,
-            posted_on=parsed["posted_on"],
-            amount=parsed["amount"],
-            description_raw__iexact=parsed["description"],
+        # The same predicate the sync uses to recognize an already-present
+        # transaction. Shared deliberately: these two drifting apart is what
+        # let a CSV row and a provider row for one purchase both exist.
+        already_in_ledger = same_transaction(
+            batch.account_id,
+            parsed["posted_on"],
+            parsed["amount"],
+            parsed["description"],
         ).count()
 
         return index_in_file < already_in_ledger

--- a/finance/services/sync.py
+++ b/finance/services/sync.py
@@ -35,6 +35,7 @@ from ..models import (
     Transaction,
     TransactionSource,
     build_fingerprint,
+    same_transaction,
 )
 from ..providers.base import ProviderAuthError, ProviderError, redact
 from ..providers.registry import get_adapter
@@ -338,6 +339,42 @@ def upsert_transaction(account: Account, payload) -> str:
             return "updated"
 
         return "unchanged"
+
+    # Before creating: is this transaction already here under a different
+    # route? A CSV import writes no provider_txn_id, so the lookup above
+    # cannot see its rows — and next_fingerprint() would step *past* the
+    # fingerprint collision rather than treating it as the duplicate signal
+    # it is. That combination created a second copy of every transaction the
+    # household imported by CSV and the provider later reported.
+    #
+    # Claiming the existing row instead is strictly better than skipping it:
+    # the row gains the provider's stable id, so every future sync updates it
+    # rather than reconsidering it, and any category already confirmed on it
+    # survives.
+    unclaimed = (
+        same_transaction(
+            account.id, payload.posted_on, payload.amount, payload.description
+        )
+        .filter(provider_txn_id="")
+        .order_by("id")
+        .first()
+    )
+
+    if unclaimed is not None:
+        unclaimed.provider_txn_id = payload.provider_txn_id
+        unclaimed.source = TransactionSource.PROVIDER
+        unclaimed.is_pending = payload.is_pending
+        unclaimed.merchant = unclaimed.merchant or payload.merchant
+        unclaimed.save(
+            update_fields=[
+                "provider_txn_id",
+                "source",
+                "is_pending",
+                "merchant",
+                "updated_at",
+            ]
+        )
+        return "updated"
 
     Transaction.objects.create(
         account=account,

--- a/finance/tests/test_csv_import.py
+++ b/finance/tests/test_csv_import.py
@@ -486,3 +486,62 @@ class ColumnMapTests(TestCase):
             column_map, {"posted_on": "Transaction Date", "description": "Payee"}
         )
         self.assertNotIn("amount_convention", column_map)
+
+
+class SourceOfTruthTests(ImportBatchTestCase):
+    """The rule both write paths follow.
+
+    **Within one source, trust it.** A CSV file listing three identical $4.75
+    coffees is asserting three coffees happened. A sync payload carrying three
+    with distinct provider ids is asserting the same. Neither gets second-
+    guessed — collapsing them would silently delete real spending.
+
+    **Across sources, deduplicate.** Two exports covering the same week, or a
+    CSV import the provider later reports, describe the same money twice.
+
+    The two halves are enforced by different mechanisms — the importer counts
+    occurrences, the sync only claims rows with no provider id — so this
+    states the shared rule in one place. Neither mechanism names it alone.
+    """
+
+    THREE_IDENTICAL = b"""Date,Description,Amount
+04/15/2026,STARBUCKS,-4.75
+04/15/2026,STARBUCKS,-4.75
+04/15/2026,STARBUCKS,-4.75
+"""
+    ONE_ROW = b"""Date,Description,Amount
+04/15/2026,STARBUCKS,-4.75
+"""
+
+    def load(self, content):
+        batch = self.make_batch(content)
+        batch = parse_batch(
+            batch, column_map=self.columns(batch), date_format="%m/%d/%Y"
+        )
+        return commit_batch(batch)
+
+    def test_one_file_listing_three_identical_rows_creates_three(self):
+        self.load(self.THREE_IDENTICAL)
+
+        self.assertEqual(Transaction.objects.count(), 3)
+
+    def test_re_importing_the_same_file_adds_nothing(self):
+        self.load(self.THREE_IDENTICAL)
+        self.load(self.THREE_IDENTICAL)
+
+        self.assertEqual(Transaction.objects.count(), 3)
+
+    def test_two_files_each_listing_one_row_describe_one_transaction(self):
+        self.load(self.ONE_ROW)
+        self.load(self.ONE_ROW)
+
+        self.assertEqual(Transaction.objects.count(), 1)
+
+    def test_a_later_cumulative_export_only_adds_what_is_new(self):
+        """The case that makes counting necessary rather than a plain
+        "does a match exist" check: one coffee was already imported, a later
+        export lists three, so two of them are genuinely new."""
+        self.load(self.ONE_ROW)
+        self.load(self.THREE_IDENTICAL)
+
+        self.assertEqual(Transaction.objects.count(), 3)

--- a/finance/tests/test_sync.py
+++ b/finance/tests/test_sync.py
@@ -684,3 +684,194 @@ class CredentialRedactionTests(TestCase):
         connection.refresh_from_db()
         self.assertNotIn("p4ssw0rd", connection.last_error)
         self.assertIn("<redacted>", connection.last_error)
+
+
+class CrossSourceDuplicateTests(SyncTestCase):
+    """A transaction imported by CSV and later reported by the provider is one
+    transaction, not two.
+
+    This is the bug that produced ten duplicates in production on a single
+    day. upsert_transaction only looked up by provider_txn_id, which a CSV row
+    does not have — and next_fingerprint() then stepped *past* the fingerprint
+    collision that would otherwise have caught it, because its job is to allow
+    genuinely repeated transactions through.
+    """
+
+    def csv_row(self, **kwargs):
+        """A row shaped the way the CSV importer writes one: no provider id."""
+        from finance.models import TransactionSource
+        from finance.services.sync import next_fingerprint
+
+        account = kwargs.pop("account")
+        defaults = {
+            "posted_on": date(2026, 4, 15),
+            "amount": Decimal("-78.00"),
+            "description_raw": "TST*THE BURROW TC",
+        }
+        defaults.update(kwargs)
+
+        return Transaction.objects.create(
+            account=account,
+            provider_txn_id="",
+            source=TransactionSource.CSV,
+            # next_fingerprint, not build_fingerprint — this mirrors what
+            # the CSV importer actually does, including walking the sequence
+            # so two identical rows can coexist.
+            fingerprint=next_fingerprint(
+                account.id,
+                defaults["posted_on"],
+                defaults["amount"],
+                defaults["description_raw"],
+            ),
+            **defaults,
+        )
+
+    def test_a_sync_claims_the_csv_row_instead_of_duplicating_it(self):
+        self.run_sync(fetch_result(transactions={}))
+        account = Account.objects.get()
+
+        self.csv_row(account=account)
+
+        self.run_sync(
+            fetch_result(
+                transactions={
+                    "ACT-1": [
+                        transaction_payload(
+                            provider_txn_id="TRN-abc",
+                            posted_on=date(2026, 4, 15),
+                            amount=Decimal("-78.00"),
+                            description="TST*THE BURROW TC",
+                        )
+                    ]
+                }
+            )
+        )
+
+        self.assertEqual(Transaction.objects.count(), 1)
+
+        claimed = Transaction.objects.get()
+        self.assertEqual(claimed.provider_txn_id, "TRN-abc")
+        self.assertEqual(claimed.source, "provider")
+
+    def test_claiming_keeps_a_category_already_confirmed_on_the_csv_row(self):
+        """The reason to claim rather than skip: work done on the CSV row —
+        a confirmed category — must not be thrown away."""
+        from django.core.management import call_command
+
+        call_command("seed_finance_categories", verbosity=0)
+        from finance.models import Category, CategorySource
+
+        self.run_sync(fetch_result(transactions={}))
+        account = Account.objects.get()
+
+        groceries = Category.objects.get(slug="food-groceries")
+        row = self.csv_row(account=account)
+        row.category = groceries
+        row.category_source = CategorySource.MANUAL
+        row.needs_review = False
+        row.save()
+
+        self.run_sync(
+            fetch_result(
+                transactions={
+                    "ACT-1": [
+                        transaction_payload(
+                            provider_txn_id="TRN-abc",
+                            posted_on=date(2026, 4, 15),
+                            amount=Decimal("-78.00"),
+                            description="TST*THE BURROW TC",
+                        )
+                    ]
+                }
+            )
+        )
+
+        claimed = Transaction.objects.get()
+        self.assertEqual(claimed.category, groceries)
+        self.assertEqual(claimed.category_source, CategorySource.MANUAL)
+
+    def test_two_genuine_repeats_still_produce_two_rows(self):
+        """The behavior claiming must not break: two identical coffees on one
+        day are two transactions, and the provider reporting both must leave
+        two rows, not one."""
+        self.run_sync(fetch_result(transactions={}))
+        account = Account.objects.get()
+
+        self.csv_row(account=account, amount=Decimal("-4.75"), description_raw="STARBUCKS")
+        self.csv_row(account=account, amount=Decimal("-4.75"), description_raw="STARBUCKS")
+
+        self.assertEqual(Transaction.objects.count(), 2)
+
+        self.run_sync(
+            fetch_result(
+                transactions={
+                    "ACT-1": [
+                        transaction_payload(
+                            provider_txn_id=f"TRN-{n}",
+                            posted_on=date(2026, 4, 15),
+                            amount=Decimal("-4.75"),
+                            description="STARBUCKS",
+                        )
+                        for n in ("a", "b")
+                    ]
+                }
+            )
+        )
+
+        self.assertEqual(Transaction.objects.count(), 2)
+        self.assertEqual(
+            sorted(Transaction.objects.values_list("provider_txn_id", flat=True)),
+            ["TRN-a", "TRN-b"],
+        )
+
+    def test_a_third_provider_copy_is_still_created(self):
+        """Claiming consumes one unclaimed row per payload. If the provider
+        reports three and only two were imported, the third is genuinely new."""
+        self.run_sync(fetch_result(transactions={}))
+        account = Account.objects.get()
+
+        self.csv_row(account=account, amount=Decimal("-4.75"), description_raw="STARBUCKS")
+
+        self.run_sync(
+            fetch_result(
+                transactions={
+                    "ACT-1": [
+                        transaction_payload(
+                            provider_txn_id=f"TRN-{n}",
+                            posted_on=date(2026, 4, 15),
+                            amount=Decimal("-4.75"),
+                            description="STARBUCKS",
+                        )
+                        for n in ("a", "b")
+                    ]
+                }
+            )
+        )
+
+        self.assertEqual(Transaction.objects.count(), 2)
+
+    def test_a_re_sync_after_claiming_does_not_duplicate(self):
+        """The claimed row now carries the provider id, so the ordinary
+        lookup finds it on every subsequent run."""
+        self.run_sync(fetch_result(transactions={}))
+        account = Account.objects.get()
+        self.csv_row(account=account)
+
+        payload = fetch_result(
+            transactions={
+                "ACT-1": [
+                    transaction_payload(
+                        provider_txn_id="TRN-abc",
+                        posted_on=date(2026, 4, 15),
+                        amount=Decimal("-78.00"),
+                        description="TST*THE BURROW TC",
+                    )
+                ]
+            }
+        )
+
+        self.run_sync(payload)
+        self.run_sync(payload)
+        self.run_sync(payload)
+
+        self.assertEqual(Transaction.objects.count(), 1)

--- a/finance/tests/test_sync.py
+++ b/finance/tests/test_sync.py
@@ -875,3 +875,68 @@ class CrossSourceDuplicateTests(SyncTestCase):
         self.run_sync(payload)
 
         self.assertEqual(Transaction.objects.count(), 1)
+
+
+class SyncTrustsItsOwnPayloadTests(SyncTestCase):
+    """The other half of the rule in test_csv_import.SourceOfTruthTests.
+
+    A sync payload carrying three identical transactions with distinct
+    provider ids is asserting three transactions happened. Claiming must
+    never collapse them — it only ever consumes rows that no provider has
+    claimed, which is exactly the CSV-imported case.
+    """
+
+    def three_identical(self):
+        return fetch_result(
+            transactions={
+                "ACT-1": [
+                    transaction_payload(
+                        provider_txn_id=f"TRN-{n}",
+                        amount=Decimal("-4.75"),
+                        description="STARBUCKS",
+                    )
+                    for n in ("a", "b", "c")
+                ]
+            }
+        )
+
+    def test_one_payload_with_three_identical_transactions_creates_three(self):
+        self.run_sync(self.three_identical())
+
+        self.assertEqual(Transaction.objects.count(), 3)
+
+    def test_re_syncing_the_same_payload_adds_nothing(self):
+        self.run_sync(self.three_identical())
+        self.run_sync(self.three_identical())
+
+        self.assertEqual(Transaction.objects.count(), 3)
+
+    def test_claiming_never_consumes_a_row_another_payload_already_claimed(self):
+        """Three provider transactions and one prior CSV row is four assertions
+        about reality minus one overlap — three transactions, not one."""
+        self.run_sync(fetch_result(transactions={}))
+        account = Account.objects.get()
+
+        from finance.models import TransactionSource
+        from finance.services.sync import next_fingerprint
+
+        Transaction.objects.create(
+            account=account,
+            provider_txn_id="",
+            source=TransactionSource.CSV,
+            posted_on=date(2026, 4, 15),
+            amount=Decimal("-4.75"),
+            description_raw="STARBUCKS",
+            fingerprint=next_fingerprint(
+                account.id, date(2026, 4, 15), Decimal("-4.75"), "STARBUCKS"
+            ),
+        )
+
+        self.run_sync(self.three_identical())
+
+        self.assertEqual(Transaction.objects.count(), 3)
+        self.assertEqual(
+            Transaction.objects.filter(provider_txn_id="").count(),
+            0,
+            "the CSV row should have been claimed, not left orphaned alongside a new one",
+        )


### PR DESCRIPTION
Fixes the duplicate transactions in production. The Burrow $78 is one of ten.

## What happened

Two code paths write transactions. **Only one checked whether the transaction was already there.**

| Path | Checks the ledger for an existing match? |
|---|---|
| CSV import (`_is_duplicate`) | ✅ by account + date + amount + description, regardless of source |
| Provider sync (`upsert_transaction`) | ❌ by `provider_txn_id` only |

A CSV row has no `provider_txn_id`, so the sync's lookup missed it and fell through to `create()`. And `next_fingerprint()` then stepped *past* the fingerprint collision that would otherwise have caught it — stepping past collisions is its whole job, because two identical coffees on one day really are two transactions.

The Burrow, exactly:

```
id=3059  src=csv       provider_id=''                fingerprint=d9c9aa…  created 08-05 01:32  (CSV batch 4)
id=4461  src=provider  provider_id='TRN-a4f41c4a…'   fingerprint=ad5df6…  created 08-06 01:01  (sync)
```

Same account, date, amount, description. Different fingerprints, because the second was assigned sequence 1 after sequence 0 came back taken. The `unique_fingerprint_per_account` constraint never had a chance to fire.

## Scope in production

22 groups share account + date + amount + description:

| Count | What | Verdict |
|---:|---|---|
| **10** | csv + provider, all 2026-08-04, account 3 | **this bug** |
| 9 | csv + csv, same import batch | file genuinely had two rows — `_is_duplicate` counts occurrences by design |
| 3 | provider + provider, **distinct** provider ids | the provider says they are two transactions |

So 10 rows to remove. I have **not** touched production data.

## The fix

`same_transaction()` in `models/transactions.py` is now the single definition of "we already have this", used by both paths. These two drifting apart is the whole bug, so they share it.

The sync **claims** the unclaimed row rather than skipping it — sets the provider id on it. Strictly better than skipping: the row gains a stable identity so future syncs update it, and any category already confirmed on it survives. All 10 production pairs happen to carry identical categories, but that is luck, not something to rely on.

Claiming consumes one unclaimed row per payload, so genuine repeats are unaffected: two imported coffees plus two reported coffees stay two rows, and a third reported coffee is still created.

## Test plan
- [x] `manage.py test finance` — 647 passed
- [x] New `CrossSourceDuplicateTests` — 5 tests: sync claims rather than duplicates; a confirmed category survives; two genuine repeats stay two; a third copy is still created; re-syncing after claiming stays at one
- [x] **Verified the tests fail without the fix** (`2 != 1`, `3 != 2`, `4 != 2`) and pass with it
- [x] `makemigrations --check` clean — no schema change